### PR TITLE
Fix to allow build flags to propagate.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ dev: all
 bin/mongrel2: build/libm2.a src/mongrel2.o
 	$(CC) $(CFLAGS) src/mongrel2.o -o $@ $< $(LIBS)
 
-build/libm2.a: OPTFLAGS = -fPIC
+build/libm2.a: OPTFLAGS += -fPIC
 build/libm2.a: build ${LIB_OBJ}
 	ar rcs $@ ${LIB_OBJ}
 	ranlib $@
@@ -123,25 +123,25 @@ manual:
 	${MAKE} -C output/docs/manual book-final.pdf
 	${MAKE} -C output/docs/manual draft
 
-netbsd: OPTFLAGS=-I/usr/local/include -I/usr/pkg/include
-netbsd: OPTLIBS=-L/usr/local/lib -L/usr/pkg/lib
+netbsd: OPTFLAGS += -I/usr/local/include -I/usr/pkg/include
+netbsd: OPTLIBS += -L/usr/local/lib -L/usr/pkg/lib
 netbsd: dev
 
 
-freebsd: OPTFLAGS=-I/usr/local/include
-freebsd: OPTLIBS=-L/usr/local/lib -pthread
+freebsd: OPTFLAGS += -I/usr/local/include
+freebsd: OPTLIBS += -L/usr/local/lib -pthread
 freebsd: all
 
-openbsd: OPTFLAGS=-I/usr/local/include
-openbsd: OPTLIBS=-L/usr/local/lib -pthread
+openbsd: OPTFLAGS += -I/usr/local/include
+openbsd: OPTLIBS += -L/usr/local/lib -pthread
 openbsd: all
 
-solaris: OPTFLAGS=-I/usr/local/include
-solaris: OPTLIBS=-L/usr/local/lib -R/usr/local/lib -lsocket -lnsl -lsendfile
+solaris: OPTFLAGS += -I/usr/local/include
+solaris: OPTLIBS += -L/usr/local/lib -R/usr/local/lib -lsocket -lnsl -lsendfile
 solaris: all
 
 
-macports: OPTFLAGS=-I/opt/local/include
-macports: OPTLIBS=-L/opt/local/lib
+macports: OPTFLAGS += -I/opt/local/include
+macports: OPTLIBS += -L/opt/local/lib
 macports: all
 

--- a/tools/filters/Makefile
+++ b/tools/filters/Makefile
@@ -1,10 +1,10 @@
 # quick Makefile to get this going, more advanced one on the way
 
 all:
-	gcc -I../../src -L../../build -fPIC -shared -nostartfiles -o test_filter.so test_filter.c ../../build/libm2.a
-	gcc -I../../src -L../../build -fPIC -shared -nostartfiles -o test_filter_a.so test_filter_a.c ../../build/libm2.a
-	gcc -I../../src -L../../build -fPIC -shared -nostartfiles -o test_filter_b.so test_filter_b.c ../../build/libm2.a
-	gcc -I../../src -L../../build -fPIC -shared -nostartfiles -o test_filter_c.so test_filter_c.c ../../build/libm2.a
+	gcc -I../../src $(OPTFLAGS) -L../../build $(OPTLIBS) -fPIC -shared -nostartfiles -o test_filter.so test_filter.c ../../build/libm2.a
+	gcc -I../../src $(OPTFLAGS) -L../../build $(OPTLIBS) -fPIC -shared -nostartfiles -o test_filter_a.so test_filter_a.c ../../build/libm2.a
+	gcc -I../../src $(OPTFLAGS) -L../../build $(OPTLIBS) -fPIC -shared -nostartfiles -o test_filter_b.so test_filter_b.c ../../build/libm2.a
+	gcc -I../../src $(OPTFLAGS) -L../../build $(OPTLIBS) -fPIC -shared -nostartfiles -o test_filter_c.so test_filter_c.c ../../build/libm2.a
 
 clean:
 	rm -f test_filter*.so


### PR DESCRIPTION
Couldn't build on OS X because it wasn't searching in /opt/local for
libraries, turns out the flags were getting overridden by the ones on
the lib.
