### PR TITLE
added dSYM directories to gitignore for OS X builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ tmp/*
 tests/coverage
 *.gcno
 *.gcda
-
+*.dSYM


### PR DESCRIPTION
simple *.dSYM at the end.

To reproduce before the merge:
$ git status
$ make clean dev
$ git status 
