### PR TITLE
fixed ticket with title "Error messages for missing variables is weird"

### DIFF
--- a/tools/m2sh/src/ast.c
+++ b/tools/m2sh/src/ast.c
@@ -153,7 +153,7 @@ bstring AST_get_bstr(tst_t *settings, tst_t *fr, bstring name, ValueType type)
 {
     Value *val = AST_get(settings, fr, name, type);
 
-    check(val != NULL, "Variable %s is expected to be a %s but it's not.", 
+    check(val != NULL, "The server is missing the '%s' variable.", 
             bdata(name), Value_type_name(type));
 
     return val->as.string->data;


### PR DESCRIPTION
The error message should be as indicated in the ticket, e.g. "The Server is missing the 'name' variable"
uuid for ticket is d9e2b8a93cc8a97a4228477c1d45038b523dab54
