### PR TITLE
Use pkg-config to get build flags for libzmq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CFLAGS=-g -O2 -Wall -Wextra -Isrc -pthread -rdynamic -DNDEBUG $(OPTFLAGS) -D_FILE_OFFSET_BITS=64
-LIBS=-lzmq -ldl -lsqlite3 $(OPTLIBS)
+CFLAGS=-g -O2 -Wall -Wextra -Isrc $(shell pkg-config --cflags libzmq) -pthread -rdynamic -DNDEBUG $(OPTFLAGS) -D_FILE_OFFSET_BITS=64
+LIBS=$(shell pkg-config --libs libzmq) -ldl -lsqlite3 $(OPTLIBS)
 PREFIX?=/usr/local
 
 get_objs = $(addsuffix .o,$(basename $(wildcard $(1))))

--- a/tests/filters/Makefile
+++ b/tests/filters/Makefile
@@ -1,5 +1,5 @@
 PREFIX?=/usr/local
-CFLAGS=-I../../src $(OPTFLAGS) -fPIC -shared -nostartfiles -L../../build
+CFLAGS=-I../../src $(shell pkg-config --cflags libzmq) $(OPTFLAGS) -fPIC -shared -nostartfiles -L../../build
 LDFLAGS=$(OPTLIBS)
 
 all: test_filter.so test_filter_a.so test_filter_b.so test_filter_c.so

--- a/tools/config_modules/Makefile
+++ b/tools/config_modules/Makefile
@@ -1,5 +1,5 @@
 PREFIX?=/usr/local
-CFLAGS=-I../../src $(OPTFLAGS) -fPIC -shared -nostartfiles -L../../build
+CFLAGS=-I../../src $(shell pkg-config --cflags libzmq) $(OPTFLAGS) -fPIC -shared -nostartfiles -L../../build
 LDFLAGS=$(OPTLIBS)
 
 all: null.so zmq.so

--- a/tools/filters/Makefile
+++ b/tools/filters/Makefile
@@ -1,5 +1,5 @@
 PREFIX?=/usr/local
-CFLAGS=-I../../src $(OPTFLAGS) -fPIC -shared -nostartfiles -L../../build
+CFLAGS=-I../../src $(shell pkg-config --cflags libzmq) $(OPTFLAGS) -fPIC -shared -nostartfiles -L../../build
 LDFLAGS=$(OPTLIBS)
 
 all: null.so

--- a/tools/m2sh/Makefile
+++ b/tools/m2sh/Makefile
@@ -1,5 +1,5 @@
-CFLAGS=-DNDEBUG -DNO_LINENOS -pthread -g -I../../src -Isrc -Wall $(OPTFLAGS)
-LIBS=-lzmq -lsqlite3 ../../build/libm2.a $(OPTLIBS)
+CFLAGS=-DNDEBUG -DNO_LINENOS -pthread -g -I../../src -Isrc $(shell pkg-config --cflags libzmq) -Wall $(OPTFLAGS)
+LIBS=$(shell pkg-config --libs libzmq) -lsqlite3 ../../build/libm2.a $(OPTLIBS)
 
 PREFIX?=/usr/local
 SOURCES=$(wildcard src/*.c)


### PR DESCRIPTION
I ran into a bit of trouble attempting to build mongrel2 in a sandbox as it couldn't find the local zeromq installation.

I addressed this by modifying the makefiles to use pkg-config to get the required cflags and libs. If a different approach would be preferred (such as using explicit ZMQ_INC/ZMQ_LIB makefile variables) then let me know and I'll rework it.

Note that if you do accept this approach we should probably also use pkg-config for sqlite3 for consistency. Again, just let me know if this is desired and I'll update the patch accordingly.
