### PR TITLE
m2sh: return correct mongrel2 running info

### DIFF
--- a/tools/m2sh/src/commands/running.c
+++ b/tools/m2sh/src/commands/running.c
@@ -286,16 +286,23 @@ static int check_server(struct ServerRun *r, tns_value_t *res)
         return 0;
     }
 
+    errno = 0;
     rc = kill(pid, 0);
 
-    if(rc != 0) {
+    if((rc != 0) && (errno == ESRCH)) {
         printf("mongrel2 at PID %d is NOT running.\n", pid);
-    } else {
+    } else if ((rc == 0) || (errno == EPERM)) {
         printf("mongrel2 at PID %d running.\n", pid);
+    } else {
+        sentinel("Could not send signal to mongrel2 at PID %d", pid);
     }
 
     r->ran = 1;
     return 0;
+
+error:
+    r->ran = 0;
+    return -1;
 }
 
 int Command_running(Command *cmd)


### PR DESCRIPTION
This fixes an issue I had when running mongrel2 as another user as myself and trying to get the state of the server by calling
m2sh running -name myserver

In this case m2sh does not have the permissions to send a signal to the mongrel2 process and did output that the server is not running. With this change a with EPERM failing kill() will assume that mongrel2 is up.
