### PR TITLE
Added mimetype for .gz extension into src/mimetypes.csql

### DIFF
--- a/tools/m2sh/src/mimetypes.csql
+++ b/tools/m2sh/src/mimetypes.csql
@@ -668,7 +668,7 @@ struct tagbstring MIMETYPES_DEFAULT_SQL = bsStatic(
 "insert into mimetype (extension, mimetype) values ('.flo', 'application/vnd.micrografx.flo');\n"
 "insert into mimetype (extension, mimetype) values ('.tgf', 'chemical/x-mdl-tgf');\n"
 "insert into mimetype (extension, mimetype) values ('.tgz', 'application/x-gtar');\n"
-"insert into mimetype (extension, mimetype) values ('.gz', 'application/x-gtar');\n"
+"insert into mimetype (extension, mimetype) values ('.gz', 'application/x-gzip');\n"
 "insert into mimetype (extension, mimetype) values ('.lhs', 'text/x-literate-haskell');\n"
 "insert into mimetype (extension, mimetype) values ('.msl', 'application/vnd.mobius.msl');\n"
 "insert into mimetype (extension, mimetype) values ('.qxd', 'application/vnd.quark.quarkxpress');\n"


### PR DESCRIPTION
Actual diff:

```
% git show ae6fda6ab1f1bf39f52ec7a1aad216c4001e54aa
commit ae6fda6ab1f1bf39f52ec7a1aad216c4001e54aa
Author: Eimantas Vaiciunas <eimantas@vaiciunas.info>
Date:   Tue Jul 19 11:03:22 2011 +0400

     added mimetype for files with .gz extension

diff --git a/tools/m2sh/src/mimetypes.csql b/tools/m2sh/src/mimetypes.csql
index 1cc057a..e361945 100644
--- a/tools/m2sh/src/mimetypes.csql
+++ b/tools/m2sh/src/mimetypes.csql
@@ -668,6 +668,7 @@ struct tagbstring MIMETYPES_DEFAULT_SQL = bsStatic(
 "insert into mimetype (extension, mimetype) values ('.flo', 'application/vnd.micrografx.flo');\n"
 "insert into mimetype (extension, mimetype) values ('.tgf', 'chemical/x-mdl-tgf');\n"
 "insert into mimetype (extension, mimetype) values ('.tgz', 'application/x-gtar');\n"
+"insert into mimetype (extension, mimetype) values ('.gz', 'application/x-gtar');\n"
 "insert into mimetype (extension, mimetype) values ('.lhs', 'text/x-literate-haskell');\n"
 "insert into mimetype (extension, mimetype) values ('.msl', 'application/vnd.mobius.msl');\n"
 "insert into mimetype (extension, mimetype) values ('.qxd', 'application/vnd.quark.quarkxpress');\n"
```
