### PR TITLE
Fixed mimetype for .gz

### DIFF
--- a/tools/m2sh/src/mimetypes.csql
+++ b/tools/m2sh/src/mimetypes.csql
@@ -668,7 +668,7 @@ struct tagbstring MIMETYPES_DEFAULT_SQL = bsStatic(
 "insert into mimetype (extension, mimetype) values ('.flo', 'application/vnd.micrografx.flo');\n"
 "insert into mimetype (extension, mimetype) values ('.tgf', 'chemical/x-mdl-tgf');\n"
 "insert into mimetype (extension, mimetype) values ('.tgz', 'application/x-gtar');\n"
-"insert into mimetype (extension, mimetype) values ('.gz', 'application/x-gtar');\n"
+"insert into mimetype (extension, mimetype) values ('.gz', 'application/x-gzip');\n"
 "insert into mimetype (extension, mimetype) values ('.lhs', 'text/x-literate-haskell');\n"
 "insert into mimetype (extension, mimetype) values ('.msl', 'application/vnd.mobius.msl');\n"
 "insert into mimetype (extension, mimetype) values ('.qxd', 'application/vnd.quark.quarkxpress');\n"


### PR DESCRIPTION
I have updated the mimetype for recently added .gz file extension. 

Kudos to Tordek. 
