### PR TITLE
m2sh segfault fix

### DIFF
--- a/tools/m2sh/src/commands/access.c
+++ b/tools/m2sh/src/commands/access.c
@@ -46,6 +46,8 @@ int Command_access_logs(Command *cmd)
     int line_number = 0;
     bstring line;
 
+    check(log_file, "Failed to open access log: %s", bdata(log_filename));
+
     while ((line = bgets((bNgetc) fgetc, log_file, '\n')) != NULL) {
         line_number++;
 
@@ -86,6 +88,7 @@ int Command_access_logs(Command *cmd)
         tns_value_destroy(log_item);
     }
 
+error: // fallthrough
     return 0;
 }
 


### PR DESCRIPTION
When running `m2sh access`, if there isn't an access log yet, or you specify the path to a non-existant file, the tool segfaults.

This patch just adds error-checking to the `fopen()`, which fixes the problem and probably a few more (`ENOACCESS`, others?).

Thanks for Mongrel2!
