### PR TITLE
solaris fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,7 @@ openbsd: all
 
 solaris: OPTFLAGS += -I/usr/local/include
 solaris: OPTLIBS += -L/usr/local/lib -R/usr/local/lib -lsocket -lnsl -lsendfile
+solaris: OPTLIBS += -L/lib -R/lib
 solaris: all
 
 

--- a/src/polarssl/net.c
+++ b/src/polarssl/net.c
@@ -63,6 +63,8 @@ static int wsa_init_done = 0;
 #include <sys/endian.h>
 #elif defined(__APPLE__)
 #include <machine/endian.h>
+#elif defined(__sun__)
+#include <sys/isa_defs.h>
 #else
 #include <endian.h>
 #endif


### PR DESCRIPTION
These two fixes will make it possible to compile mongrel2 on solaris 11 and openindiana.
