### PR TITLE
Develop: fixes compile error by changing "const int" to "#define"

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -196,7 +196,7 @@ error:
     return CLOSE;
 }
 
-const int CERT_FINGERPRINT_SIZE = 20;
+#define CERT_FINGERPRINT_SIZE 20
 
 void Connection_fingerprint_from_cert(Connection *conn) 
 {


### PR DESCRIPTION
I was getting a compile error from the develop branch. The message was "src/connection.c:212:9: error: variable-sized object may not be initialized". So I fixed it by changing "const int" to "#define".
