### PR TITLE
Develop: fixed procer build issue

### DIFF
--- a/tools/procer/Makefile
+++ b/tools/procer/Makefile
@@ -7,7 +7,7 @@ all: procer
 
 
 procer: ../../build/libm2.a ${OBJECTS}
-	gcc $(OPTFLAGS) $(OPTLIBS) -o $@ ${OBJECTS} ${LIBS} ../../build/libm2.a
+	gcc $(OPTFLAGS) $(OPTLIBS) -o $@ ${OBJECTS} ../../build/libm2.a ${LIBS}
 
 clean:
 	rm -f *.o procer


### PR DESCRIPTION
Fixed procer build errors by moving ${LIBS}  to the end of the line. Otherwise procer was not finding zmq stuff
