### PR TITLE
Fix ssl_send to send data in chunks of SSL_MAX_CONTENT_LEN

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -142,12 +142,20 @@ error:
 
 static ssize_t ssl_send(IOBuf *iob, char *buffer, int len)
 {
+    ssize_t sent = 0;
+
     check(iob->use_ssl, "IOBuf not set up to use ssl");
     if(!iob->handshake_performed) {
         int rcode = ssl_do_handshake(iob);
         check(rcode == 0, "handshake failed");
     }
-    return ssl_write(&iob->ssl, (const unsigned char*) buffer, len);
+
+    do {
+        // must send in chunks of SSL_MAX_CONTENT_LEN
+        sent += ssl_write(&iob->ssl, (const unsigned char*) (buffer + sent), (len - sent));
+    } while (sent < len);	
+
+    return sent;
 error:
     return -1;
 }


### PR DESCRIPTION
This patch fixes a bug in mongrel2 that break handlers responses greater than 16k (SSL_MAX_CONTENT_LEN). There is a thread about this issue at [mongrel2 list](http://librelist.com/browser//mongrel2/2012/2/10/mongrel2-is-not-sending-responses-above-16k/)
