### PR TITLE
Ignoring tools/procer/procer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ tools/lemon/lemon
 tools/m2sh/build/
 tools/m2sh/tests/*_tests
 tools/m2sh/tests/tests.log
+tools/procer/procer
 run/*
 logs/*
 tmp/*


### PR DESCRIPTION
It's a product of the build process and as such shouldn't be included in git.
