### PR TITLE
Fix/polarssl; memset with incorrect size, doesn't erase full target

### DIFF
--- a/src/polarssl/cipher.c
+++ b/src/polarssl/cipher.c
@@ -245,7 +245,7 @@ int cipher_init_ctx( cipher_context_t *ctx, const cipher_info_t *cipher_info )
     if( NULL == cipher_info || NULL == ctx )
         return POLARSSL_ERR_CIPHER_BAD_INPUT_DATA;
 
-    memset( ctx, 0, sizeof( ctx ) );
+    memset( ctx, 0, sizeof *ctx );
 
     if( NULL == ( ctx->cipher_ctx = cipher_info->base->ctx_alloc_func() ) )
         return POLARSSL_ERR_CIPHER_ALLOC_FAILED;


### PR DESCRIPTION
I found a defect in polarssl cipher.c while compiling for OS-X.  An incorrect parameter to the sizeof operator was used, resulting in only clearing 4/8 bytes of the target, instead of the complete structure.  I've submitted this fix upstream, but we should fix it here, too.
