### PR TITLE
Fix/installbin; don't interfere with target directory unless necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,11 @@ filters: build/libm2.a
 config_modules: build/libm2.a
 	${MAKE} ${MAKEOPTS} -C tools/config_modules all
 
+# Try to install first before creating target directory and trying again
 install: all
-	install -d $(DESTDIR)/$(PREFIX)/bin/
-	install bin/mongrel2 $(DESTDIR)/$(PREFIX)/bin/
+	install bin/mongrel2 $(DESTDIR)/$(PREFIX)/bin/ \
+	    || ( install -d $(DESTDIR)/$(PREFIX)/bin/ \
+	        && install bin/mongrel2 $(DESTDIR)/$(PREFIX)/bin/ )
 	${MAKE} ${MAKEOPTS} -C tools/m2sh install
 	${MAKE} ${MAKEOPTS} -C tools/config_modules install
 	${MAKE} ${MAKEOPTS} -C tools/filters install


### PR DESCRIPTION
Quite often, the ownership and permissions of /usr/local/bin have been crafted to allow certain parties to install and manage software installed there. 

Unless we cannot install, don't attempt to create or modify the permissions of the target .../bin/ directory by running "install -d ...", which attempts to change the permissions unnecessarily.
