### PR TITLE
Feature/forward: Request remembers raw 0MQ message for later forwarding

### DIFF
--- a/examples/python/mongrel2/request.py
+++ b/examples/python/mongrel2/request.py
@@ -56,3 +56,13 @@ class Request(object):
         if self.msg:
             socket.send( self.msg )
         return self.msg
+
+    def encode(self):
+        """
+        Makes a raw message out of the Request object to be forwarded.
+        """
+        self.msg = " ".join([
+            self.sender, self.conn_id, self.path,
+            tnetstrings.dump(json.dumps(self.headers)) + tnetstrings.dump(self.body)
+         ])
+        return self.msg


### PR DESCRIPTION
If a Python 0MQ handler wants to pass along an incoming Mongrel2 message to another handler, it cannot -- the original incoming raw message from Mongrel2 has been discarded.  If a handler wants to create and/or modify a Request, and then send it to another Handler for processing, the raw message must be created "by hand" -- there is no means to create a parse-able message built into the Request class.

Arrange for m2py's Request object to remember the raw message it was parsed from.  Add a forward(socket) method to allow the message to be easily forwarded along to the specified socket, and an encode() method to store a new raw message representing the Request (suitable for a future forward(socket), for example).

This allows a Python handler to use m2py's handler.Connection in both the traditional way -- to receive Requests from Mongrel2, and to send responses back to Mongrel2, _or_ -- to receive messages "forwarded" from some other Python handler, and then to send responses back to Mongrel2!

Very useful, if you want to write a broker to partially process Requests (say, for authentication), and then decide to forward them along to a set of sub-handlers for actually processing and generating the response to Mongrel2.

In addition, you can now produce a Request (manually, if you wish), and encode() it into a raw message, and forward it to a socket so that it may be received and parsed by another handler.

Request.parse(msg) -- returns a Request parsed from 'msg', which now also retains original msg
Request.forward(socket) -- forwards original msg to supplied 0MQ socket
Request.encode() -- formulate, save and return a new raw message encoding the contents of the Request 
