### PR TITLE
Feature/redirect scheme

### DIFF
--- a/src/dir.c
+++ b/src/dir.c
@@ -61,7 +61,7 @@ const char *RESPONSE_FORMAT = "HTTP/1.1 200 OK\r\n"
     "\r\n\r\n";
 
 const char *DIR_REDIRECT_FORMAT = "HTTP/1.1 301 Moved Permanently\r\n"
-    "Location: http://%s%s/\r\n"
+    "Location: //%s%s/\r\n"
     "Content-Length: 0\r\n"
     "Server: " VERSION
     "\r\n\r\n";


### PR DESCRIPTION
Using a network-path reference means that the user-agent will continue
using the current URI scheme.

This fixes issue #7
