### PR TITLE
Feature/connection fix

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -900,7 +900,7 @@ int Connection_deliver(Connection *conn, bstring buf)
     check(conn->iob != NULL, "There's no IOBuffer to send to, Tell Zed.");
     /* The deliver task will free the buffer */
     rc = Connection_deliver_enqueue(conn,b64_buf);
-    check_debug(rc == blength(b64_buf)+1, "Failed to write entire message to conn %d", IOBuf_fd(conn->iob));
+    check_debug(rc == 0, "Failed to write message to conn %d", IOBuf_fd(conn->iob));
 
     return 0;
 

--- a/tests/connection_tests.c
+++ b/tests/connection_tests.c
@@ -20,23 +20,6 @@ char *test_Connection_create_destroy()
     return NULL;
 }
 
-char *test_Connection_deliver()
-{
-    bstring t1;
-    const char remote[IPADDR_SIZE];
-    Connection *conn = Connection_create(NULL, 1, 0, remote);
-    mu_assert(conn != NULL, "Failed to create a connection.");
-
-    int rc = Connection_deliver(conn, t1 = bfromcstr("TEST"));
-    // depending on the platform this will fail or not if send is allowed on files
-    mu_assert(rc == -1, "Should NOT be able to write.");
-
-    Connection_destroy(conn);
-    bdestroy(t1);
-
-    return NULL;
-}
-
 int test_task_with_sample(const char *sample_file)
 {
     (void)sample_file;
@@ -99,7 +82,6 @@ char * all_tests() {
     Server_set_default_host(SRV, zedshaw_com);
 
     mu_run_test(test_Connection_create_destroy);
-    mu_run_test(test_Connection_deliver);
     mu_run_test(test_Connection_task);
 
     Server_destroy(SRV);


### PR DESCRIPTION
Also remove a broken test, this should probably be replaced.

Problem was that Connection_enqueue adds a bstring to its queue, then returns 0 for success. The caller then makes a silly check for number of bytes written which seems to be left over from previous changes. Since that will fail it jumps straight into the error label which frees the bstring. Later on when the task runs it tries to use said freed bstring.
