### PR TITLE
[SECURITY] Disable RC4 ciphersuites

### DIFF
--- a/src/polarssl/config.h
+++ b/src/polarssl/config.h
@@ -309,7 +309,7 @@
  *      TLS_RSA_WITH_RC4_128_MD5
  *      TLS_RSA_WITH_RC4_128_SHA
  */
-#define POLARSSL_ARC4_C
+/*#define POLARSSL_ARC4_C*/
 
 /**
  * \def POLARSSL_ASN1_PARSE_C


### PR DESCRIPTION
As advised by [PolarSSL Security Advisory 2013-02](https://polarssl.org/tech-updates/security-advisories/polarssl-security-advisory-2013-02)
