### PR TITLE
REMOTE_ADDR and option no_clobber_xff

### DIFF
--- a/src/headers.c
+++ b/src/headers.c
@@ -55,6 +55,7 @@ struct tagbstring HTTP_PATTERN = bsStatic("PATTERN");
 struct tagbstring HTTP_URL_SCHEME = bsStatic("URL_SCHEME");
 struct tagbstring HTTP_HTTP = bsStatic("http");
 struct tagbstring HTTP_HTTPS = bsStatic("https");
+struct tagbstring HTTP_REMOTE_ADDR = bsStatic("REMOTE_ADDR");
 
 
 struct tagbstring HTTP_CONTENT_LENGTH = bsStatic("content-length");

--- a/src/headers.h
+++ b/src/headers.h
@@ -66,5 +66,6 @@ extern struct tagbstring HTTP_EXPECT;
 extern struct tagbstring HTTP_URL_SCHEME;
 extern struct tagbstring HTTP_HTTP;
 extern struct tagbstring HTTP_HTTPS;
+extern struct tagbstring HTTP_REMOTE_ADDR;
 
 #endif

--- a/src/request.c
+++ b/src/request.c
@@ -404,6 +404,7 @@ bstring Request_to_tnetstring(Request *req, bstring uuid, int fd, const char *bu
     }
 
     tns_render_hash_pair(&outbuf, &HTTP_METHOD, method);
+    tns_render_hash_pair(&outbuf, &HTTP_REMOTE_ADDR, bfromcstr(conn->remote));
 
     check(tns_render_request_end(&outbuf, header_start, uuid, id, Request_path(req)) != -1, "Failed to finalize request.");
 
@@ -490,6 +491,8 @@ bstring Request_to_payload(Request *req, bstring uuid, int fd, const char *buf, 
     } else {
         B(headers, &HTTP_URL_SCHEME, &HTTP_HTTP);
     }
+
+    B(headers, &HTTP_REMOTE_ADDR, bfromcstr(conn->remote));
 
     bconchar(headers, '}');
 

--- a/tests/request_tests.c
+++ b/tests/request_tests.c
@@ -167,7 +167,7 @@ char *test_Request_create()
 }
 
 struct tagbstring COOKIE_HEADER = bsStatic("cookie");
-struct tagbstring EXPECTED_COOKIE_HEADER = bsStatic("JSON 1 / 117:{\"PATH\":\"/\",\"cookie\":[\"foo=bar\",\"test=yes; go=no\"],\"METHOD\":\"GET\",\"VERSION\":\"HTTP/1.0\",\"URI\":\"/\",\"URL_SCHEME\":\"http\"},0:,");
+struct tagbstring EXPECTED_COOKIE_HEADER = bsStatic("JSON 1 / 134:{\"PATH\":\"/\",\"cookie\":[\"foo=bar\",\"test=yes; go=no\"],\"METHOD\":\"GET\",\"VERSION\":\"HTTP/1.0\",\"URI\":\"/\",\"URL_SCHEME\":\"http\",\"REMOTE_ADDR\":\"\"},0:,");
 
 char *test_Multiple_Header_Request() 
 {


### PR DESCRIPTION
In handler mode, set special header REMOTE_ADDR containing the IP address of the requesting client. Setting no_clobber_xff prevents X-FORWARDED-FOR from being touched in handler mode.

Proxy mode remains unchanged. REMOTE_ADDR is not set in that context, and X-FORWARDED-FOR is always set/replaced (no_clobber_xff has no effect on proxy mode).
