### PR TITLE
add zmq_compat check for libzmq 4

### DIFF
--- a/src/zmq_compat.h
+++ b/src/zmq_compat.h
@@ -67,6 +67,8 @@
 #     define zmq_msg_recv(msg, sock, opt) zmq_recvmsg(sock, msg, opt)
 #  endif
 #  define ZMQ_POLL_MSEC    1           //  zmq_poll is msec
+#elif ZMQ_VERSION_MAJOR >= 4
+#  define ZMQ_POLL_MSEC    1           //  zmq_poll is msec
 #endif
 
 #endif /* ! defined( _ZMQ_COMPAT_H ) */


### PR DESCRIPTION
Fixes missing ZMQ_POLL_MSEC, which was undefined with libzmq 4.
No other necessary changes to work with current libzmq.
