### PR TITLE
The sendfile filter fails unless Dir is also used

### DIFF
--- a/src/dir.c
+++ b/src/dir.c
@@ -180,21 +180,23 @@ error:
     return -1;
 }
 
-
-Dir *Dir_create(bstring base, bstring index_file, bstring default_ctype, int cache_ttl)
+void Dir_init(void)
 {
-    Dir *dir = calloc(sizeof(Dir), 1);
-    check_mem(dir);
-
-    dir->running = 1;
-
     if(!MAX_SEND_BUFFER || !MAX_DIR_PATH) {
         MAX_SEND_BUFFER = Setting_get_int("limits.dir_send_buffer", 16 * 1024);
         MAX_DIR_PATH = Setting_get_int("limits.dir_max_path", 256);
         log_info("MAX limits.dir_send_buffer=%d, limits.dir_max_path=%d",
                 MAX_SEND_BUFFER, MAX_DIR_PATH);
     }
+}
 
+Dir *Dir_create(bstring base, bstring index_file, bstring default_ctype, int cache_ttl)
+{
+    Dir_init();
+    Dir *dir = calloc(sizeof(Dir), 1);
+    check_mem(dir);
+
+    dir->running = 1;
     dir->base = bstrcpy(base);
     check(blength(dir->base) < MAX_DIR_PATH, "Base directory is too long, must be less than %d", MAX_DIR_PATH);
     check(bchar(dir->base, blength(dir->base) - 1) == '/', "End directory base with / in %s or it won't work right.", bdata(base));

--- a/src/dir.h
+++ b/src/dir.h
@@ -80,6 +80,8 @@ typedef struct Dir {
     int cache_ttl;
 } Dir;
 
+void Dir_init(void);
+
 Dir *Dir_create(bstring base, bstring index_file,
                 bstring default_ctype, int cache_ttl);
 

--- a/tools/filters/sendfile.c
+++ b/tools/filters/sendfile.c
@@ -5,6 +5,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <connection.h>
+#include <dir.h>
 
 static int mydispatch(Connection *conn, tns_value_t *data)
 {
@@ -43,6 +44,7 @@ struct tagbstring SENDFILE = bsStatic("sendfile");
 deliver_function xrequest_init(Server *srv, bstring load_path, tns_value_t *config, bstring **keys, int *nkeys)
 {
     static bstring sendfile=&SENDFILE;
+    Dir_init();
     *keys=&sendfile;
     *nkeys=1;
     return mydispatch;


### PR DESCRIPTION
The sendfile needs the MAX_SEND_BUFFER variable, but it is initialized only in Dir_create, so in a server that uses sendfile filters only, any request fail as the buffer has a size of 0 bytes.

I'm not sure if this patch is the most clever way to fix the issue, as it makes the sendfile filter depend on Dir. A solution would be to move MAX_SEND_BUFFER to io.c because currently Dir and IO depends on each other.
