### PR TITLE
Log real host name and not the rule that matched

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -233,7 +233,11 @@ static inline bstring make_log_message(Request *req, const char *remote_addr,
     tns_render_string_prepend(&outbuf, b_temp);
     bdestroy(b_temp);
 
-    tns_render_string_prepend(&outbuf, req->host_name);
+    if (req->host_name != NULL) {
+        tns_render_string_prepend(&outbuf, req->host_name);
+    } else {
+        tns_render_string_prepend(&outbuf, req->target_host->name);
+    }
 
     tns_render_log_end(&outbuf);
 


### PR DESCRIPTION
I don't know if its a bug or if it is on purpose, but on access log, the rule that matched the domain is logged rather than the actual request domain.
In my configuration I use a catch-all on subdomain, resulting in `(.*).mydomain.com` in logs which is not really useful. This patch logs the actual domain name.
