### PR TITLE
Delete gcov files more selectively.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ clean:
 	rm -f tests/empty.sqlite 
 	rm -f tools/lemon/lemon
 	rm -f tools/m2sh/tests/tests.log 
-	find . -name "*.gc*" -exec rm {} \;
+	find . \( -name "*.gcno" -o -name "*.gcda" \) -exec rm {} \;
 	${MAKE} -C tools/m2sh OPTLIB=${OPTLIB} clean
 	${MAKE} -C tools/filters OPTLIB=${OPTLIB} clean
 	${MAKE} -C tests/filters OPTLIB=${OPTLIB} clean


### PR DESCRIPTION
Previously, make target 'clean' would delete all '_.gc_' files, this would
erroneously delete 'src/polarssl/tests/suites/test_suite_cipher.gcm.data'.

This contributed to marking the src/polarssl submodule dirty and caused
polarssl's test suite to fail (as was noticed and worked around in issue #206).

With this patch, it deletes only '_.gcno' and '_.gcda' files.
