### PR TITLE
Closing the temporary file before notifying about upload completion

### DIFF
--- a/src/upload.c
+++ b/src/upload.c
@@ -119,12 +119,15 @@ int Upload_file(Connection *conn, Handler *handler, int content_len)
     rc = stream_to_disk(conn->iob, content_len, tmpfd);
     check(rc == 0, "Failed to stream to disk.");
 
+    // close the file before notifying on upload completion
+    fdclose(tmpfd);
+
     rc = Upload_notify(conn, handler, "done", tmp_name);
     check(rc == 0, "Failed to notify the end of the upload.");
 
     bdestroy(result);
     bdestroy(tmp_name);
-    fdclose(tmpfd);
+
     return 0;
 
 error:


### PR DESCRIPTION
mkstemp() opens the file with O_EXCL, so notifying upload handler about completion before actually closing the file can lead to a race condition where the handler fails to open() the file because the close() on the original file descriptor returned by mkstemp() has not been called yet. 
