### PR TITLE
Disable SSLv3 in the PolarSSL configuration

### DIFF
--- a/src/polarssl_config.h
+++ b/src/polarssl_config.h
@@ -588,7 +588,7 @@
  *
  * Comment this macro to disable support for SSL 3.0
  */
-#define POLARSSL_SSL_PROTO_SSL3
+// #define POLARSSL_SSL_PROTO_SSL3
 
 /**
  * \def POLARSSL_SSL_PROTO_TLS1


### PR DESCRIPTION
Hi,

I have update the polarssl configuration file to disable the SSLv3 which is deprecated from the POODLE attack.
More details on google security blog : http://googleonlinesecurity.blogspot.fr/2014/10/this-poodle-bites-exploiting-ssl-30.html

Thanks,
