### PR TITLE
Switch polarssl from HAVGE to default RNG.

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -947,7 +947,7 @@ Connection *Connection_create(Server *srv, int fd, int rport,
     check_mem(conn->req);
 
     if(srv != NULL && srv->use_ssl) {
-        conn->iob = IOBuf_create(BUFFER_SIZE, fd, IOBUF_SSL);
+        conn->iob = IOBuf_create_ssl(BUFFER_SIZE, fd, &srv->ctr_drbg);
         check(conn->iob != NULL, "Failed to create the SSL IOBuf.");
 
         // set default cert

--- a/src/io.c
+++ b/src/io.c
@@ -41,10 +41,10 @@
 #include "register.h"
 #include "mem/halloc.h"
 #include "dbg.h"
-#include "polarssl/havege.h"
 #include "polarssl/ssl.h"
 #include "task/task.h"
 #include "adt/darray.h"
+#include "polarssl/ctr_drbg.h"
 
 int IO_SSL_VERIFY_METHOD = SSL_VERIFY_NONE;
 
@@ -353,12 +353,14 @@ error:
 
 
 
-static inline int iobuf_ssl_setup(IOBuf *buf)
+static inline int iobuf_ssl_setup(ctr_drbg_context *rng_ctx, IOBuf *buf)
 {
     int rc = 0;
 
     buf->use_ssl = 1;
     buf->handshake_performed = 0;
+
+    memset(&buf->ssl, 0, sizeof(ssl_context));
 
     rc = ssl_init(&buf->ssl);
     check(rc == 0, "Failed to initialize SSL structure.");
@@ -366,8 +368,7 @@ static inline int iobuf_ssl_setup(IOBuf *buf)
     ssl_set_endpoint(&buf->ssl, SSL_IS_SERVER);
     ssl_set_authmode(&buf->ssl, IO_SSL_VERIFY_METHOD);
 
-    havege_init(&buf->hs);
-    ssl_set_rng(&buf->ssl, havege_random, &buf->hs);
+    ssl_set_rng(&buf->ssl, ctr_drbg_random, rng_ctx);
 
 #ifndef DEBUG
     ssl_set_dbg(&buf->ssl, ssl_debug, NULL);
@@ -386,7 +387,8 @@ error:
     return -1;
 }
 
-IOBuf *IOBuf_create(size_t len, int fd, IOBufType type)
+static IOBuf *IOBuf_create_internal(size_t len, int fd, IOBufType type,
+        ctr_drbg_context *rng_ctx)
 {
     IOBuf *buf = malloc(sizeof(IOBuf));
     check_mem(buf);
@@ -402,7 +404,8 @@ IOBuf *IOBuf_create(size_t len, int fd, IOBufType type)
     buf->use_ssl = 0;
 
     if(type == IOBUF_SSL) {
-        check(iobuf_ssl_setup(buf) != -1, "Failed to setup SSL.");
+        check(rng_ctx != NULL, "IOBUF_SSL requires non-null server");
+        check(iobuf_ssl_setup(rng_ctx, buf) != -1, "Failed to setup SSL.");
         buf->send = ssl_send;
         buf->recv = ssl_recv;
         buf->stream_file = ssl_stream_file;
@@ -427,6 +430,19 @@ IOBuf *IOBuf_create(size_t len, int fd, IOBufType type)
 error:
     if(buf) h_free(buf);
     return NULL;
+}
+
+IOBuf *IOBuf_create(size_t len, int fd, IOBufType type)
+{
+    check(type != IOBUF_SSL, "Use IOBuf_create_ssl for ssl IOBuffers")
+    return IOBuf_create_internal(len, fd, type, NULL);
+error:
+    return NULL;
+}
+
+IOBuf *IOBuf_create_ssl(size_t len, int fd, ctr_drbg_context *rng_ctx)
+{
+    return IOBuf_create_internal(len,fd,IOBUF_SSL,rng_ctx);
 }
 
 int IOBuf_close(IOBuf *buf)

--- a/src/io.h
+++ b/src/io.h
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <polarssl/x509.h>
 #include <polarssl/ssl.h>
-#include <polarssl/havege.h>
+#include "server.h"
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #include "bsd_specific.h"
@@ -58,6 +58,7 @@ typedef struct IOBuf {
     havege_state hs;
 } IOBuf;
 
+IOBuf *IOBuf_create_ssl(size_t len, int fd, ctr_drbg_context *rng_ctx);
 IOBuf *IOBuf_create(size_t len, int fd, IOBufType type);
 
 void IOBuf_resize(IOBuf *buf, size_t new_size);

--- a/src/server.h
+++ b/src/server.h
@@ -40,6 +40,8 @@
 #include "host.h"
 #include "routing.h"
 #include <polarssl/ssl.h>
+#include <polarssl/entropy.h>
+#include <polarssl/ctr_drbg.h>
 #include <polarssl/x509.h>
 #include <polarssl/pk.h>
 
@@ -66,6 +68,8 @@ typedef struct Server {
     bstring default_hostname;
     uint32_t created_on;
     int use_ssl;
+    entropy_context entropy;
+    ctr_drbg_context ctr_drbg;
     x509_crt own_cert;
     x509_crt ca_chain;
     pk_context pk_key;


### PR DESCRIPTION
Also centralize RNG to be server-wide.  This allows using /dev/urandom
entropy for initialization before chroot()