### PR TITLE
Rename symbol to prevent conflict

### DIFF
--- a/src/mem/align.h
+++ b/src/mem/align.h
@@ -30,7 +30,7 @@ union max_align
 	void (*q)(void);
 };
 
-typedef union max_align max_align_t;
+typedef union max_align h_max_align_t;
 
 #endif
 

--- a/src/mem/halloc.c
+++ b/src/mem/halloc.c
@@ -34,7 +34,7 @@ typedef struct hblock
 #endif
 	hlist_item_t  siblings; /* 2 pointers */
 	hlist_head_t  children; /* 1 pointer  */
-	max_align_t   data[1];  /* not allocated, see below */
+	h_max_align_t   data[1];  /* not allocated, see below */
 	
 } hblock_t;
 


### PR DESCRIPTION
One of the standard headers defines max_align_t on some versions of linux.