### PR TITLE
Update site links to mongrel2/mongrel2 and update release

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Features
 Download
 --------
 
-Mongrel2 is now 1.8.0 as of *Thu Jul 26 06:06 GMT 2012*: 
+Mongrel2 is now 1.9.3 as of *Sat Aug 22 04:32 GMT 2015*: 
 
-* [mongrel2-1.8.0.tar.bz2](https://github.com/zedshaw/mongrel2/tarball/v1.8.0) MD5: 4bca0d299e7e77efa4c674bc5877dfd0
+* [mongrel2-1.9.3.tar.bz2](https://github.com/mongrel2/mongrel2/releases/download/v1.9.3/mongrel2-v1.9.3.tar.bz2) MD5: c3a2e9c5c878cc055a09e50cfcc95a05
 
 Documentation
 -------------

--- a/docs/manual/inputs/cloning_mongrel2_source.sh
+++ b/docs/manual/inputs/cloning_mongrel2_source.sh
@@ -1,2 +1,2 @@
-git clone https://github.com/zedshaw/mongrel2.git
+git clone https://github.com/mongrel2/mongrel2.git
 cd mongrel2

--- a/docs/site/src/downloads/index.json
+++ b/docs/site/src/downloads/index.json
@@ -4,45 +4,63 @@
 
     "releases": [
         { 
+            "version": "1.9.3",
+            "md5": "c3a2e9c5c878cc055a09e50cfcc95a05",
+            "link": "https://github.com/mongrel2/mongrel2/releases/download/v1.9.3/mongrel2-v1.9.3.tar.bz2",
+            "date": "Aug 22 2015"
+        },
+        { 
+            "version": "1.9.2",
+            "md5": "e49d8bfae45591089375b1e0eab3d6b8",
+            "link": "https://github.com/mongrel2/mongrel2/releases/download/1.9.2/mongrel2-v1.9.2.tar.bz2",
+            "date": "Apr 09 2015"
+        },
+        { 
+            "version": "1.9.1",
+            "md5": "1c70020368dd70c0a714c7c24a7c5929",
+            "link": "https://github.com/mongrel2/mongrel2/releases/download/v1.9.1/mongrel2-v1.9.1.tar.gz",
+            "date": "Apr 09 2014"
+        },
+        { 
             "version": "1.9.0",
             "md5": "f5de1c6b40c90e411689bef884208776",
-            "link": "https://github.com/zedshaw/mongrel2/releases/download/v1.9.0/mongrel2-v1.9.0.tar.gz",
+            "link": "https://github.com/mongrel2/mongrel2/releases/download/v1.9.0/mongrel2-v1.9.0.tar.gz",
             "date": "Jan 26 2014"
         },
         { 
             "version": "1.8.1",
             "md5": "e7890c77f494b6d15ebcd871be3d58d0",
-            "link": "https://github.com/zedshaw/mongrel2/tarball/v1.8.1",
+            "link": "https://github.com/mongrel2/mongrel2/tarball/v1.8.1",
             "date": "May 25 2013"
         },
         { 
             "version": "1.8.0",
             "md5": "4bca0d299e7e77efa4c674bc5877dfd0",
-            "link": "https://github.com/zedshaw/mongrel2/tarball/v1.8.0",
+            "link": "https://github.com/mongrel2/mongrel2/tarball/v1.8.0",
             "date": "Jun 22 2011"
         },
         {
             "version": "1.7.5",
             "md5": "923c6403d037dc7d0a016df1b3d14be6",
-            "link": "https://github.com/zedshaw/mongrel2/tarball/v1.7.5",
+            "link": "https://github.com/mongrel2/mongrel2/tarball/v1.7.5",
             "date": "Jun 22 2011"
         },
         { 
             "version": "1.7.4",
             "md5": "c9fbb0ee71b3a7ac69907536b991aa31",
-            "link": "https://github.com/zedshaw/mongrel2/tarball/v1.7.4",
+            "link": "https://github.com/mongrel2/mongrel2/tarball/v1.7.4",
             "date": "Jun 14 2011"
         },
         { 
             "version": "1.7.3",
             "md5": "2e31b1457c67191608d2f1caceeb0a3d",
-            "link": "https://github.com/zedshaw/mongrel2/tarball/v1.7.3",
+            "link": "https://github.com/mongrel2/mongrel2/tarball/v1.7.3",
             "date": "Jun 01 2011"
         },
         { 
             "version": "1.6",
             "md5": "ecdeae16046853bf57fd5aab82bf2d23",
-            "link": "https://github.com/zedshaw/mongrel2/tarball/v1.6",
+            "link": "https://github.com/mongrel2/mongrel2/tarball/v1.6",
             "date": "May 01 2011"
         },
     ]

--- a/docs/site/src/wiki/contributor_instructions.md
+++ b/docs/site/src/wiki/contributor_instructions.md
@@ -34,7 +34,7 @@ How do I get the source code?
 --------
 
 The source code is currently maintained using git and the code itself is hosted
-on github. The project is at [https://github.com/zedshaw/mongrel2](https://github.com/zedshaw/mongrel2).
+on github. The project is at [https://github.com/mongrel2/mongrel2](https://github.com/mongrel2/mongrel2).
 
 The two branches available are:
 

--- a/docs/site/src/wiki/quick_start.md
+++ b/docs/site/src/wiki/quick_start.md
@@ -35,7 +35,7 @@ Getting The Source
 Quickest way to do that is to grab the tarball
 
 <pre>
-wget https://github.com/zedshaw/mongrel2/releases/download/v1.9.0/mongrel2-v1.9.0.tar.gz
+wget https://github.com/mongrel2/mongrel2/releases/download/v1.9.0/mongrel2-v1.9.0.tar.gz
 </pre>
 
 

--- a/docs/site/views/header.html
+++ b/docs/site/views/header.html
@@ -61,8 +61,8 @@
 							</li>
 							<li><a href="/downloads/">Downloads</a>
 								<ul>
-									<li><a href="https://github.com/zedshaw/mongrel2/releases/download/v1.9.0/mongrel2-v1.9.0.tar.gz">Latest tar.gz</a></li>
-									<li><a href="http://github.com/zedshaw/mongrel2">git repo</a></li>
+									<li><a href="https://github.com/mongrel2/mongrel2/releases/download/v1.9.3/mongrel2-v1.9.3.tar.bz2">Latest tar.bz2</a></li>
+									<li><a href="http://github.com/mongrel2/mongrel2">git repo</a></li>
 									<li><a href="/downloads/">Old Releases</a></li>
 								</ul>
 							</li>

--- a/docs/site/views/index.html
+++ b/docs/site/views/index.html
@@ -5,12 +5,12 @@
         <div class="column-container">
             <div class="column three-fourths">
                 <h3><em>Get the latest Mongrel2 source.</em></h3>
-                <p class="no-margin">Mongrel2 version 1.9.0 is available for download 
-                (MD5: f5de1c6b40c90e411689bef884208776).</p>
+                <p class="no-margin">Mongrel2 version 1.9.3 is available for download 
+                (MD5: c3a2e9c5c878cc055a09e50cfcc95a05).</p>
             </div><!-- end .column -->
             <div class="column fourth">
 
-                <a href="https://github.com/zedshaw/mongrel2/releases/download/v1.9.0/mongrel2-v1.9.0.tar.gz" class="button">
+                <a href="https://github.com/mongrel2/mongrel2/releases/download/v1.9.3/mongrel2-v1.9.3.tar.bz2" class="button">
                     Download Mongrel2
                     <span class="icon"></span>
                 </a>
@@ -150,7 +150,7 @@
                     The source code?
                 </h4>
                 <p>
-                <strong>You can checkout the git repository at <a href="http://github.com/zedshaw/mongrel2">github.com/zedshaw/mongrel2</a> or get the <a href="/downloads/">latest tar.bz2</a>.</strong>
+                <strong>You can checkout the git repository at <a href="http://github.com/mongrel2/mongrel2">github.com/mongrel2/mongrel2</a> or get the <a href="/downloads/">latest tar.bz2</a>.</strong>
                 </p>
                 <p>
                 You'll want the <em>develop</em> branch for the latest development 

--- a/docs/wiki/ContributorInstructions.wiki
+++ b/docs/wiki/ContributorInstructions.wiki
@@ -31,7 +31,7 @@ and get a good understanding of the project before you continue.
 <h2>How do I get the source code?</h2>
 
 The source code is currently maintained using git and the code itself is hosted
-on github. The project is at https://github.com/zedshaw/mongrel2.
+on github. The project is at https://github.com/mongrel2/mongrel2.
 
 For information on how to use github see http://help.github.com/
 


### PR DESCRIPTION
Updates the links in the README and web site to reflect the migration from the zedshaw/mongrel2 repo to mongrel2/mongrel2.
Adds listings for releases 1.9.1, 1.9.2, and 1.9.3.
Changes the "latest" download links to point to 1.9.3.

I got the new MD5 sums by downloading the release tarballs from GitHub and checking their sums. This assumes that the files I downloaded from GitHub aren't already compromised.

Closes #237
Fixes #278 