### PR TITLE
notify disconnections immediately

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -99,6 +99,7 @@ typedef struct Connection {
     Rendez deliverRendez;
     Rendez uploadRendez;
     int sendCredits;
+    int sentToHandler;
 } Connection;
 
 void Connection_destroy(Connection *conn);


### PR DESCRIPTION
A flag on the connection is used so we only send this event if we had previously sent a message to the handler.