### PR TITLE
fix for handler notifications and pipelining

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -99,7 +99,6 @@ typedef struct Connection {
     Rendez deliverRendez;
     Rendez uploadRendez;
     int sendCredits;
-    int sentToHandler;
 } Connection;
 
 void Connection_destroy(Connection *conn);


### PR DESCRIPTION
Got rid of conn->sentToHandler and now just use conn->handler, which was already used by the websocket code. This way we keep track of which Handler we are talking to last and don't need to extract it from the Request object.