### PR TITLE
if entropy source unavailable, fallback to previous rng behavior (havege)

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -1055,7 +1055,7 @@ Connection *Connection_create(Server *srv, int fd, int rport,
     Request_set_relaxed(conn->req, RELAXED_PARSING);
 
     if(srv != NULL && srv->use_ssl) {
-        conn->iob = IOBuf_create_ssl(BUFFER_SIZE, fd, &srv->ctr_drbg);
+        conn->iob = IOBuf_create_ssl(BUFFER_SIZE, fd, srv->rng_func, srv->rng_ctx);
         check(conn->iob != NULL, "Failed to create the SSL IOBuf.");
 
         // set default cert

--- a/src/io.c
+++ b/src/io.c
@@ -46,7 +46,6 @@
 #include "polarssl/ssl.h"
 #include "task/task.h"
 #include "adt/darray.h"
-#include "polarssl/ctr_drbg.h"
 
 int IO_SSL_VERIFY_METHOD = SSL_VERIFY_NONE;
 
@@ -380,7 +379,7 @@ error:
 
 
 
-static inline int iobuf_ssl_setup(ctr_drbg_context *rng_ctx, IOBuf *buf)
+static inline int iobuf_ssl_setup(int (*rng_func)(void *, unsigned char *, size_t), void *rng_ctx, IOBuf *buf)
 {
     int rc = 0;
 
@@ -395,7 +394,7 @@ static inline int iobuf_ssl_setup(ctr_drbg_context *rng_ctx, IOBuf *buf)
     ssl_set_endpoint(&buf->ssl, SSL_IS_SERVER);
     ssl_set_authmode(&buf->ssl, IO_SSL_VERIFY_METHOD);
 
-    ssl_set_rng(&buf->ssl, ctr_drbg_random, rng_ctx);
+    ssl_set_rng(&buf->ssl, rng_func, rng_ctx);
 
 #ifndef DEBUG
     ssl_set_dbg(&buf->ssl, ssl_debug, NULL);
@@ -415,7 +414,7 @@ error:
 }
 
 static IOBuf *IOBuf_create_internal(size_t len, int fd, IOBufType type,
-        ctr_drbg_context *rng_ctx)
+        int (*rng_func)(void *, unsigned char *, size_t), void *rng_ctx)
 {
     IOBuf *buf = malloc(sizeof(IOBuf));
     check_mem(buf);
@@ -433,8 +432,8 @@ static IOBuf *IOBuf_create_internal(size_t len, int fd, IOBufType type,
     buf->ssl_sent_close = 0;
 
     if(type == IOBUF_SSL) {
-        check(rng_ctx != NULL, "IOBUF_SSL requires non-null server");
-        check(iobuf_ssl_setup(rng_ctx, buf) != -1, "Failed to setup SSL.");
+        check(rng_func != NULL, "IOBUF_SSL requires non-null server");
+        check(iobuf_ssl_setup(rng_func, rng_ctx, buf) != -1, "Failed to setup SSL.");
         buf->send = ssl_send;
         buf->recv = ssl_recv;
         buf->stream_file = ssl_stream_file;
@@ -464,14 +463,14 @@ error:
 IOBuf *IOBuf_create(size_t len, int fd, IOBufType type)
 {
     check(type != IOBUF_SSL, "Use IOBuf_create_ssl for ssl IOBuffers")
-    return IOBuf_create_internal(len, fd, type, NULL);
+    return IOBuf_create_internal(len, fd, type, NULL, NULL);
 error:
     return NULL;
 }
 
-IOBuf *IOBuf_create_ssl(size_t len, int fd, ctr_drbg_context *rng_ctx)
+IOBuf *IOBuf_create_ssl(size_t len, int fd, int (*rng_func)(void *, unsigned char *, size_t), void *rng_ctx)
 {
-    return IOBuf_create_internal(len,fd,IOBUF_SSL,rng_ctx);
+    return IOBuf_create_internal(len,fd,IOBUF_SSL,rng_func,rng_ctx);
 }
 
 int IOBuf_close(IOBuf *buf)

--- a/src/io.h
+++ b/src/io.h
@@ -57,10 +57,9 @@ typedef struct IOBuf {
     int ssl_sent_close;
     ssl_context ssl;
     ssl_session ssn;
-    havege_state hs;
 } IOBuf;
 
-IOBuf *IOBuf_create_ssl(size_t len, int fd, ctr_drbg_context *rng_ctx);
+IOBuf *IOBuf_create_ssl(size_t len, int fd, int (*rng_func)(void *, unsigned char *, size_t), void *rng_ctx);
 IOBuf *IOBuf_create(size_t len, int fd, IOBufType type);
 
 void IOBuf_resize(IOBuf *buf, size_t new_size);

--- a/src/mongrel2.c
+++ b/src/mongrel2.c
@@ -420,6 +420,13 @@ void taskmain(int argc, char **argv)
     rc = attempt_chroot_drop(srv);
     check(rc == 0, "Major failure in chroot/droppriv, aborting."); 
 
+    // set up rng after chroot
+    // TODO: once mbedtls is updated, we can move this back into Server_create
+    if(srv->use_ssl) {
+        rc = Server_init_rng(srv);
+        check(rc == 0, "Failed to initialize rng for server %s", bdata(srv->uuid));
+    }
+
     final_setup();
 
     taskcreate(tickertask, NULL, TICKER_TASK_STACK);

--- a/src/server.h
+++ b/src/server.h
@@ -41,7 +41,6 @@
 #include "routing.h"
 #include <polarssl/ssl.h>
 #include <polarssl/entropy.h>
-#include <polarssl/ctr_drbg.h>
 #include <polarssl/x509.h>
 #include <polarssl/pk.h>
 
@@ -69,7 +68,8 @@ typedef struct Server {
     uint32_t created_on;
     int use_ssl;
     entropy_context entropy;
-    ctr_drbg_context ctr_drbg;
+    int (*rng_func)(void *, unsigned char *, size_t);
+    void *rng_ctx;
     x509_crt own_cert;
     x509_crt ca_chain;
     pk_context pk_key;
@@ -108,5 +108,7 @@ void Server_queue_push(Server *srv);
 #define Server_queue_latest() darray_last(SERVER_QUEUE)
 
 int Server_queue_destroy();
+
+int Server_init_rng(Server *srv);
 
 #endif


### PR DESCRIPTION
This ensures SSL doesn't fail due to /dev/urandom being inaccessible from chroot. We simply revert to the original behavior.