### PR TITLE
port to mbedtls 2.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ dev: CFLAGS=-g -Wall -Isrc -Wall -Wextra $(OPTFLAGS) -D_FILE_OFFSET_BITS=64
 dev: all
 
 ${OBJECTS_NOEXT}: CFLAGS += ${NOEXTCFLAGS}
-${OBJECTS}: src/mbedtls/include/polarssl/config.h
+${OBJECTS}: src/mbedtls/include/mbedtls/config.h
 
 # 
 # CFLAGS_DEFS: The $(CC) flags required to obtain C pre-processor #defines, per:
@@ -55,24 +55,24 @@ CFLAGS_DEFS=-dM -E -x c 	# clang, gcc, HP C, Intel icc
 
 # Configure mbedtls
 # 
-# - check for required src/mbedtls/include/polarssl/config.h definitions
-#   and patch using version-appropriate src/polarssl_config.patch.#.#.# file:
+# - check for required src/mbedtls/include/mbedtls/config.h definitions
+#   and patch using version-appropriate src/mbedtls_config.patch.#.#.# file:
 #   - If desired mbedtls version is not yet supported, git checkout the
-#     new src/mbedtls/ version X.Y.Z, edit its include/polarssl/config.h as
-#     required, and generate a new src/polarssl_config.patch.X.Y.Z using:
+#     new src/mbedtls/ version X.Y.Z, edit its include/mbedtls/config.h as
+#     required, and generate a new src/mbedtls_config.patch.X.Y.Z using:
 # 
-#         git diff -- include/polarssl/config.h > ../polarssl_config.patch.X.Y.Z
+#         git diff -- include/mbedtls/config.h > ../mbedtls_config.patch.X.Y.Z
 FORCE:
-src/mbedtls/include/polarssl/config.h: src/mbedtls/include/polarssl/version.h FORCE
-	@POLARSSL_VERSION=$$( $(CC) $(CFLAGS_DEFS) $<				\
-	    | sed -n -e 's/^.*POLARSSL_VERSION_STRING[\t ]*"\([^"]*\)".*/\1/p' ); \
-	if $(CC) $(CFLAGS_DEFS) $@ | grep -q POLARSSL_HAVEGE_C; then		\
-	    echo "mbedtls $${POLARSSL_VERSION}; already configured";		\
+src/mbedtls/include/mbedtls/config.h: src/mbedtls/include/mbedtls/version.h FORCE
+	@MBEDTLS_VERSION=$$( $(CC) $(CFLAGS_DEFS) $<				\
+	    | sed -n -e 's/^.*MBEDTLS_VERSION_STRING[\t ]*"\([^"]*\)".*/\1/p' ); \
+	if $(CC) $(CFLAGS_DEFS) $@ | grep -q MBEDTLS_HAVEGE_C; then		\
+	    echo "mbedtls $${MBEDTLS_VERSION}; already configured";		\
 	else									\
-	    echo "mbedtls $${POLARSSL_VERSION}; defining POLARSSL_HAVEGE_C...";\
-	    POLARSSL_PATCH=src/polarssl_config.patch.$${POLARSSL_VERSION};	\
-	    if ! patch -d src/mbedtls -p 1 < $${POLARSSL_PATCH}; then		\
-		echo "*** Failed to apply $${POLARSSL_PATCH}";			\
+	    echo "mbedtls $${MBEDTLS_VERSION}; defining MBEDTLS_HAVEGE_C...";\
+	    MBEDTLS_PATCH=src/mbedtls_config.patch.$${MBEDTLS_VERSION};	\
+	    if ! patch -d src/mbedtls -p 1 < $${MBEDTLS_PATCH}; then		\
+		echo "*** Failed to apply $${MBEDTLS_PATCH}";			\
 		exit 1;								\
 	    fi;									\
 	fi
@@ -99,7 +99,7 @@ clean:
 	rm -f tools/lemon/lemon
 	rm -f tools/m2sh/tests/tests.log 
 	find . \( -name "*.gcno" -o -name "*.gcda" \) -exec rm {} \;
-	if test -e .git; then git -C src/mbedtls checkout include/polarssl/config.h; fi
+	if test -e .git; then git -C src/mbedtls checkout include/mbedtls/config.h; fi
 	${MAKE} -C tools/m2sh OPTLIB=${OPTLIB} clean
 	${MAKE} -C tools/filters OPTLIB=${OPTLIB} clean
 	${MAKE} -C tests/filters OPTLIB=${OPTLIB} clean

--- a/src/chunked.c
+++ b/src/chunked.c
@@ -1,8 +1,6 @@
 #include "chunked.h"
 
 #include <string.h>
-#include <polarssl/sha1.h>
-#include "dbg.h"
 #include "connection.h"
 
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))

--- a/src/connection.h
+++ b/src/connection.h
@@ -82,8 +82,8 @@ typedef struct Connection {
 
     // if SNI is used, then the connection has its own cert
     int use_sni;
-    x509_crt own_cert;
-    pk_context pk_key;
+    mbedtls_x509_crt own_cert;
+    mbedtls_pk_context pk_key;
 
     int rport;
     State state;

--- a/src/io.h
+++ b/src/io.h
@@ -6,8 +6,8 @@
 #endif
 
 #include <stdlib.h>
-#include <polarssl/x509.h>
-#include <polarssl/ssl.h>
+#include <mbedtls/x509.h>
+#include <mbedtls/ssl.h>
 #include "server.h"
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
@@ -53,14 +53,18 @@ typedef struct IOBuf {
 
     int fd;
     int use_ssl;
+    int ssl_initialized;
     int handshake_performed;
     int ssl_sent_close;
-    ssl_context ssl;
-    ssl_session ssn;
+    mbedtls_ssl_config sslconf;
+    mbedtls_ssl_context ssl;
+    mbedtls_ssl_session ssn;
 } IOBuf;
 
 IOBuf *IOBuf_create_ssl(size_t len, int fd, int (*rng_func)(void *, unsigned char *, size_t), void *rng_ctx);
 IOBuf *IOBuf_create(size_t len, int fd, IOBufType type);
+
+int IOBuf_ssl_init(IOBuf *buf);
 
 void IOBuf_resize(IOBuf *buf, size_t new_size);
 

--- a/src/mbedtls_config.patch.2.2.0
+++ b/src/mbedtls_config.patch.2.2.0
@@ -1,0 +1,48 @@
+diff --git a/include/mbedtls/config.h b/include/mbedtls/config.h
+index 3e39998..b0bd575 100644
+--- a/include/mbedtls/config.h
++++ b/include/mbedtls/config.h
+@@ -595,7 +595,7 @@
+  *      MBEDTLS_TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA
+  *      MBEDTLS_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
+  */
+-#define MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
++// #define MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
+ 
+ /**
+  * \def MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+@@ -1058,7 +1058,7 @@
+  *
+  * Comment this macro to disable support for SSL 3.0
+  */
+-#define MBEDTLS_SSL_PROTO_SSL3
++// #define MBEDTLS_SSL_PROTO_SSL3
+ 
+ /**
+  * \def MBEDTLS_SSL_PROTO_TLS1
+@@ -1458,7 +1458,7 @@
+  *      MBEDTLS_TLS_RSA_PSK_WITH_RC4_128_SHA
+  *      MBEDTLS_TLS_PSK_WITH_RC4_128_SHA
+  */
+-#define MBEDTLS_ARC4_C
++// #define MBEDTLS_ARC4_C
+ 
+ /**
+  * \def MBEDTLS_ASN1_PARSE_C
+@@ -1684,6 +1684,7 @@
+  * This module is used by the following key exchanges:
+  *      DHE-RSA, DHE-PSK
+  */
++// Only weak ciphers !
+ #define MBEDTLS_DHM_C
+ 
+ /**
+@@ -1811,7 +1812,7 @@
+  *
+  * Uncomment to enable the HAVEGE random generator.
+  */
+-//#define MBEDTLS_HAVEGE_C
++#define MBEDTLS_HAVEGE_C
+ 
+ /**
+  * \def MBEDTLS_HMAC_DRBG_C

--- a/src/server.h
+++ b/src/server.h
@@ -39,10 +39,10 @@
 #include "adt/darray.h"
 #include "host.h"
 #include "routing.h"
-#include <polarssl/ssl.h>
-#include <polarssl/entropy.h>
-#include <polarssl/x509.h>
-#include <polarssl/pk.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/x509.h>
+#include <mbedtls/pk.h>
 
 enum {
      /* IPv6 addr can be up to 40 chars long */
@@ -67,12 +67,12 @@ typedef struct Server {
     bstring default_hostname;
     uint32_t created_on;
     int use_ssl;
-    entropy_context entropy;
+    mbedtls_entropy_context entropy;
     int (*rng_func)(void *, unsigned char *, size_t);
     void *rng_ctx;
-    x509_crt own_cert;
-    x509_crt ca_chain;
-    pk_context pk_key;
+    mbedtls_x509_crt own_cert;
+    mbedtls_x509_crt ca_chain;
+    mbedtls_pk_context pk_key;
     const int *ciphers;
     char *dhm_P;
     char *dhm_G;

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -1,6 +1,6 @@
 #include <websocket.h>
 #include <dbg.h>
-#include <polarssl/sha1.h>
+#include <mbedtls/sha1.h>
 
 struct tagbstring WS_REQ_METHOD = bsStatic("HYBI");
 struct tagbstring WS_CONNECTION = bsStatic("connection");
@@ -61,7 +61,7 @@ bstring websocket_challenge(bstring input)
 
     check(BSTR_OK == bcatcstr(tmpstring, WS_GUID),"Failed to allocate memory");
 
-    sha1((unsigned char *)bdata(tmpstring),blength(tmpstring),(unsigned char *)bdata(buf));
+    mbedtls_sha1((unsigned char *)bdata(tmpstring),blength(tmpstring),(unsigned char *)bdata(buf));
     buf->slen=20;
     encodedSha1=bBase64Encode(buf);
 

--- a/tests/cert_tests.c
+++ b/tests/cert_tests.c
@@ -1,34 +1,34 @@
 #include "minunit.h"
 #include "stdio.h"
-#include "polarssl/x509_crt.h"
-#include "polarssl/error.h"
+#include "mbedtls/x509_crt.h"
+#include "mbedtls/error.h"
 char *test_SSL_verify_cert() 
 {
 
-    x509_crt crt;
+    mbedtls_x509_crt crt;
     memset( &crt, 0, sizeof crt );
 
-    x509_crt ca_crt;
+    mbedtls_x509_crt ca_crt;
     memset( &ca_crt, 0, sizeof ca_crt );
 
-    x509_crl crl;
+    mbedtls_x509_crl crl;
     memset( &crl, 0, sizeof crl );
 
     int ret = 0;
 
-    ret =x509_crt_parse_file( &crt, "tests/ca/certs/m2-cert.pem" );
+    ret =mbedtls_x509_crt_parse_file( &crt, "tests/ca/certs/m2-cert.pem" );
 
     mu_assert(ret == 0, "failed to parse cert m2-cert.pem");
 
-    ret =x509_crt_parse_file( &ca_crt, "tests/ca/none.pem" );
+    ret =mbedtls_x509_crt_parse_file( &ca_crt, "tests/ca/none.pem" );
 
     mu_assert(ret != 0, "failed to fail on non-existent pem none.pem");
 
-    ret =x509_crt_parse_file( &ca_crt, "tests/ca/cacert.pem" );
+    ret =mbedtls_x509_crt_parse_file( &ca_crt, "tests/ca/cacert.pem" );
 
     mu_assert(ret == 0, "failed to parse cert cacert.pem");
 
-    ret =x509_crl_parse_file( &crl, "tests/ca/crl.pem" );
+    ret =mbedtls_x509_crl_parse_file( &crl, "tests/ca/crl.pem" );
 
     mu_assert(ret == 0, "failed to parse cert crl.pem");
 
@@ -39,19 +39,19 @@ char *test_SSL_verify_cert()
      * test outcome accordingly.  However, log the failure to stderr so that the maintainer can
      * detect the expiry of the cert, and generate/commit a new one from time to time.
      */
-    int flags = 0;
-    ret =x509_crt_verify( &crt, &ca_crt, NULL, NULL, &flags, NULL, NULL);
+    uint32_t flags = 0;
+    ret =mbedtls_x509_crt_verify( &crt, &ca_crt, NULL, NULL, &flags, NULL, NULL);
     if ( ret ) {
 	char buf[1024];
 	buf[0] = 0;
-	polarssl_strerror( ret, buf, sizeof buf );
+	mbedtls_strerror( ret, buf, sizeof buf );
 	fprintf( stderr, "*** x509_crt_verify of m2-cert.pem: %d: %s\n", ret, buf );
     }
-    int valid_from = x509_time_expired( &crt.valid_from );
-    int valid_to   = x509_time_expired( &crt.valid_to );
+    int valid_from = mbedtls_x509_time_is_past( &crt.valid_from );
+    int valid_to   = mbedtls_x509_time_is_past( &crt.valid_to );
 
     int expected = 0;
-    if ( valid_from == BADCERT_EXPIRED && valid_to == BADCERT_EXPIRED ) {
+    if ( valid_from == MBEDTLS_X509_BADCERT_EXPIRED && valid_to == MBEDTLS_X509_BADCERT_EXPIRED ) {
 	/*
 	 * This cert hasn't yet become active, or has already expired; expect
 	 * X509 cert failure (-0x2700)
@@ -60,13 +60,13 @@ char *test_SSL_verify_cert()
 	       crt.valid_from.year, crt.valid_from.mon, crt.valid_from.day, crt.valid_from.hour, crt.valid_from.min, crt.valid_from.sec, valid_from,
 	       crt.valid_to  .year, crt.valid_to  .mon, crt.valid_to  .day, crt.valid_to  .hour, crt.valid_to  .min, crt.valid_to  .sec, valid_to );
 	fprintf( stderr, "*** If this is the currently supported version, generate and commit a new tests/ca/m2-cert.pem with valid dates\n" );
-	expected = POLARSSL_ERR_X509_CERT_VERIFY_FAILED;
+	expected = MBEDTLS_ERR_X509_CERT_VERIFY_FAILED;
     }
     mu_assert(ret == expected, "failed to verify cert m2-cert.pem");
 
-    x509_crt_free( &crt );
-    x509_crt_free( &ca_crt );
-    x509_crl_free( &crl );
+    mbedtls_x509_crt_free( &crt );
+    mbedtls_x509_crt_free( &ca_crt );
+    mbedtls_x509_crl_free( &crl );
 
     return NULL;
 }


### PR DESCRIPTION
Porting to 2.x is mostly about prefixing symbols with `mbedtls_`. However there were a couple of API differences that had to be adapted to. The biggest issue is that mbedtls introduced a new structure called `ssl_config`, and some settings go in there rather than `ssl_context`, and once config settings are applied they cannot be further altered. This was a little tricky in the current codebase because settings that fall into the config category were changed in multiple places.