### PR TITLE
support authbind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-g -O2 -Wall -Wextra -Isrc -Isrc/mbedtls/include -pthread -rdynamic -DNDEBUG $(OPTFLAGS) -D_FILE_OFFSET_BITS=64
+CFLAGS=-g -O2 -Wall -Wextra -Isrc -Isrc/mbedtls/include -pthread -rdynamic -DNDEBUG $(OPTFLAGS) -D_FILE_OFFSET_BITS=64 -DAUTHBIND_HELPER=\"/usr/lib/authbind/helper\"
 LIBS=-lzmq -ldl -lsqlite3 $(OPTLIBS)
 PREFIX?=/usr/local
 


### PR DESCRIPTION
This adds support for authbind, which allows binding to privileged ports without needing root access. It works by dynamically invoking the authbind-helper program if it is available. Support is enabled by defining AUTHBIND_HELPER at compilation time.

Even though Mongrel2 supports dropping privileges, the Debian package maintainer insists that authbind is the preferred approach vs launching Mongrel2 as root.