### PR TITLE
fix reloading more than once

### DIFF
--- a/src/mongrel2.c
+++ b/src/mongrel2.c
@@ -382,6 +382,7 @@ void reload_task(void *data)
             if(rotate_logs()) {
                 log_err("Error rotating logs!");
             }
+            RELOAD = 0;
         } else {
             log_info("Shutdown requested, goodbye.");
             break;


### PR DESCRIPTION
When the actual server reload code was removed in favor of mere log rotation, we forgot to reset this flag.