### PR TITLE
Allow path normalization to work in absence of PATH_MAX

### DIFF
--- a/src/unixy.c
+++ b/src/unixy.c
@@ -214,21 +214,3 @@ int Unixy_daemonize(int dochdir)
 error:
     return -1;
 }
-
-
-bstring Unixy_getcwd()
-{
-    char *wd = calloc(PATH_MAX + 1, 1);
-    bstring dir = NULL;
-
-    check(getcwd(wd, PATH_MAX-1), "Could not get current working directory.");
-    wd[PATH_MAX] = '\0';
-
-    dir = bfromcstr(wd);
-
-error:
-    // fall through
-    free(wd);
-    return dir;
-}
-

--- a/tests/unixy_tests.c
+++ b/tests/unixy_tests.c
@@ -3,20 +3,10 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-char *test_Unixy_getcwd()
-{
-    bstring dir = Unixy_getcwd();
-    mu_assert(dir != NULL, "getcwd failed.");
-    debug("CWD is: %s", bdata(dir));
-
-    bdestroy(dir);
-    return NULL;
-}
 
 char *test_Unixy_chroot_fails()
 {
-    bstring dir = Unixy_getcwd();
-    mu_assert(dir != NULL, "can't getcwd in chroot test.");
+    bstring dir = bfromcstr(".");
 
     int rc = Unixy_chroot(dir);
     mu_assert(rc == -1, "We shouldn't be able to chroot unless running as root.");
@@ -28,13 +18,12 @@ char *test_Unixy_chroot_fails()
 
 char *test_Unixy_drop_priv_fails()
 {
-    bstring dir = Unixy_getcwd();
-    mu_assert(dir != NULL, "can't getcwd in chroot test.");
 
+    bstring dir = bfromcstr(".");
     Unixy_drop_priv(dir);
     // the results of this are so variable we can't check it
-    
     bdestroy(dir);
+    
     return NULL;
 }
 
@@ -61,7 +50,6 @@ char *test_Unixy_pid_file()
 char * all_tests() {
     mu_suite_start();
 
-    mu_run_test(test_Unixy_getcwd);
     if(getuid() != 0) {
         mu_run_test(test_Unixy_chroot_fails);
         mu_run_test(test_Unixy_drop_priv_fails);


### PR DESCRIPTION
PATH_MAX may not always be defined.

Fixes #305