### PR TITLE
send initial download credits only once per connection

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -98,6 +98,7 @@ typedef struct Connection {
     int deliverBytesPending;
     Rendez deliverRendez;
     Rendez uploadRendez;
+    int downloadCreditsInitialized;
     int sendCredits;
     int closing;
 } Connection;


### PR DESCRIPTION
Since request IDs made over the same connection are reused, download credits are really connection-based rather than request-based. Initial credits should be provided only at the time of the first request. All credits after that are given whenever writes to connections succeed.

Re-giving credits for each new request actually causes an overgiving of credits, since the handler will have already gotten credits for all of its earlier writes. The handler then ends up with more credits than MAX_CREDITS, which may cause the handler to write too much in the next response, causing the connection to be dropped (Mongrel2 kills the connection if pending bytes exceeds MAX_CREDITS).