### PR TITLE
Make build-directories order-only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,12 @@ LIB_SRC=$(filter-out src/mongrel2.c,${SOURCES})
 LIB_OBJ=$(filter-out src/mongrel2.o,${OBJECTS})
 TEST_SRC=$(wildcard tests/*_tests.c)
 TESTS=$(patsubst %.c,%,${TEST_SRC})
-MAKEOPTS=OPTFLAGS="${NOEXTCFLAGS} ${OPTFLAGS}" LIBS="${LIBS}" DESTDIR="${DESTDIR}" PREFIX="${PREFIX}"
+MAKEOPTS=OPTFLAGS="${CFLAGS} ${NOEXTCFLAGS} ${OPTFLAGS}" LIBS="${LIBS}" DESTDIR="${DESTDIR}" PREFIX="${PREFIX}"
 
 all: bin/mongrel2 tests m2sh procer
 
 ${OBJECTS_NOEXT}: CFLAGS += ${NOEXTCFLAGS}
-${OBJECTS}: builddirs
+${OBJECTS}: | builddirs
 
 .PHONY: builddirs
 builddirs:


### PR DESCRIPTION
Directories change their modification time, so can't directly depend on
them.  Instead there is a rule to ensure that they exist.  What was
missing is that the dependency should not force a rebuild of everything
that depends on it.