### PR TITLE
Fix for uninitialized memory after array expansion

### DIFF
--- a/src/adt/darray.c
+++ b/src/adt/darray.c
@@ -89,7 +89,7 @@ int darray_expand(darray_t *array)
             "Failed to expand array to new size: %d",
             array->max + (int)array->expand_rate);
 
-    memset(array->contents + old_max, 0, array->expand_rate + 1);
+    memset(array->contents + old_max, 0, array->expand_rate * sizeof(void *));
     return 0;
 
 error:


### PR DESCRIPTION
Valgrind complains about "Conditional jump or move depends on uninitialised value(s)" because memset isn't properly initializing the newly expanded chunk of the darray. I tested this by throwing 1000000 values in a darray then clearing it, and noticed Valgrind didn't like line 67 in darray_clear().

```
if(array->contents[i] != NULL) {
```

Because it's potentially uninitialized