### PR TITLE
Make HAVEGE dependency optional

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -171,6 +171,7 @@ int Server_init_rng(Server *srv)
         srv->rng_func = mbedtls_ctr_drbg_random;
         srv->rng_ctx = ctx;
     } else {
+#ifdef MBEDTLS_HAVEGE_C
         log_warn("entropy source unavailable. falling back to havege rng");
 
         ctx = calloc(sizeof(mbedtls_havege_state), 1);
@@ -178,6 +179,9 @@ int Server_init_rng(Server *srv)
 
         srv->rng_func = mbedtls_havege_random;
         srv->rng_ctx = ctx;
+#else
+	sentinel("No entropy source available, SSL is not possible (disable chroot?)\n");
+#endif
     }
 
     return 0;


### PR DESCRIPTION
Recent mbedTLS versions will use getrandom(2) on linux, and people deploying in
a container may not need the chroot(), so urandom will be available.  In any
event many platform mbedTLS packages do not have HAVEGE, and it's only required
for SSL support, so we shouldn't hard depend on it.

This will now exit with an error message if the platform entropy
initialiazation fails and HAVEGE is not supported.

fixes #331