### PR TITLE
Fix warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ PREFIX?=/usr/local
 get_objs = $(addsuffix .o,$(basename $(wildcard $(1))))
 
 ASM=$(wildcard src/**/*.S src/*.S)
-RAGEL_TARGETS=src/state.c src/http11/http11_parser.c
+RAGEL_TARGETS=src/state.c src/http11/http11_parser.c src/handler_parser.c src/http11/httpclient_parser.c
+RAGEL_OBJECTS=$(patsubst %.c,%.o,${RAGEL_TARGETS})
 SOURCES=$(wildcard src/**/*.c src/*.c) $(RAGEL_TARGETS)
 OBJECTS=$(patsubst %.c,%.o,${SOURCES}) $(patsubst %.S,%.o,${ASM})
 OBJECTS_NOEXT=$(filter-out ${OBJECTS_EXTERNAL},${OBJECTS})
@@ -21,6 +22,7 @@ all: bin/mongrel2 tests m2sh procer
 
 ${OBJECTS_NOEXT}: CFLAGS += ${NOEXTCFLAGS}
 ${OBJECTS}: | builddirs
+$(RAGEL_OBJECTS): CFLAGS += -Wno-unused-const-variable -Wimplicit-fallthrough=0
 
 .PHONY: builddirs
 builddirs:

--- a/src/server.h
+++ b/src/server.h
@@ -75,8 +75,8 @@ typedef struct Server {
     mbedtls_x509_crt ca_chain;
     mbedtls_pk_context pk_key;
     const int *ciphers;
-    char *dhm_P;
-    char *dhm_G;
+    const char *dhm_P;
+    const char *dhm_G;
 } Server;
 
 Server *Server_create(bstring uuid, bstring default_host,

--- a/src/unused.h
+++ b/src/unused.h
@@ -1,0 +1,10 @@
+#ifndef __unused_h__
+#define __unused_h__
+
+#if defined(__GNUC__) || defined(__clang__)
+#define UNUSED __attribute__((unused))
+#else
+#define UNUSED
+#endif
+
+#endif

--- a/tests/bstr_tests.c
+++ b/tests/bstr_tests.c
@@ -1254,7 +1254,8 @@ static int test15_0 (bstring b0, int pos, const_bstring b1, unsigned char fill, 
 
         rv = bsetstr (b2, pos, b1, fill);
         ret += (rv == 0); if (ret && 0 == linenum) linenum = __LINE__;
-        if (!biseq (b0, b2)) ret++; if (ret && 0 == linenum) linenum = __LINE__;
+        if (!biseq (b0, b2)) ret++;
+        if (ret && 0 == linenum) linenum = __LINE__;
 
         debug ("%d, %s, %02X) = %s", pos, dumpBstring (b1), fill, dumpBstring (b2));
 

--- a/tests/filters/test_filter.c
+++ b/tests/filters/test_filter.c
@@ -1,13 +1,14 @@
 #include <filter.h>
 #include <dbg.h>
+#include <unused.h>
 
-StateEvent filter_transition(StateEvent state, Connection *conn)
+StateEvent filter_transition(UNUSED StateEvent state, UNUSED Connection *conn)
 {
     return CLOSE;
 }
 
 
-StateEvent *filter_init(Server *srv, bstring load_path, int *out_nstates)
+StateEvent *filter_init(UNUSED Server *srv, UNUSED bstring load_path, int *out_nstates)
 {
     StateEvent states[] = {HANDLER};
     *out_nstates = Filter_states_length(states);

--- a/tests/filters/test_filter_a.c
+++ b/tests/filters/test_filter_a.c
@@ -1,5 +1,6 @@
 #include <filter.h>
 #include <dbg.h>
+#include <unused.h>
 
 StateEvent filter_transition(StateEvent state, Connection *conn)
 {
@@ -8,7 +9,7 @@ StateEvent filter_transition(StateEvent state, Connection *conn)
 }
 
 
-StateEvent *filter_init(Server *srv, bstring load_path, int *out_nstates)
+StateEvent *filter_init(UNUSED Server *srv, UNUSED bstring load_path, int *out_nstates)
 {
     StateEvent states[] = {CONNECT};
     *out_nstates = Filter_states_length(states);

--- a/tests/filters/test_filter_b.c
+++ b/tests/filters/test_filter_b.c
@@ -1,5 +1,6 @@
 #include <filter.h>
 #include <dbg.h>
+#include <unused.h>
 
 StateEvent filter_transition(StateEvent state, Connection *conn)
 {
@@ -8,7 +9,7 @@ StateEvent filter_transition(StateEvent state, Connection *conn)
 }
 
 
-StateEvent *filter_init(Server *srv, bstring load_path, int *out_nstates)
+StateEvent *filter_init(UNUSED Server *srv, UNUSED bstring load_path, int *out_nstates)
 {
     StateEvent states[] = {CONNECT};
     *out_nstates = Filter_states_length(states);

--- a/tests/filters/test_filter_c.c
+++ b/tests/filters/test_filter_c.c
@@ -1,14 +1,15 @@
 #include <filter.h>
 #include <dbg.h>
+#include <unused.h>
 
-StateEvent filter_transition(StateEvent state, Connection *conn)
+StateEvent filter_transition(UNUSED StateEvent state, Connection *conn)
 {
 	conn->rport += 5;
     return CLOSE;
 }
 
 
-StateEvent *filter_init(Server *srv, bstring load_path, int *out_nstates)
+StateEvent *filter_init(UNUSED Server *srv, UNUSED bstring load_path, int *out_nstates)
 {
     StateEvent states[] = {CONNECT};
     *out_nstates = Filter_states_length(states);

--- a/tools/config_modules/null.c
+++ b/tools/config_modules/null.c
@@ -36,6 +36,7 @@
 #include <dbg.h>
 #include <config/module.h>
 #include <config/db.h>
+#include <unused.h>
 
 struct tagbstring GOODPATH = bsStatic("goodpath");
 
@@ -54,32 +55,32 @@ void config_close()
 {
 }
 
-tns_value_t *config_load_handler(int handler_id)
+tns_value_t *config_load_handler(UNUSED int handler_id)
 {
     return NULL;
 }
 
-tns_value_t *config_load_proxy(int proxy_id)
+tns_value_t *config_load_proxy(UNUSED int proxy_id)
 {
     return NULL;
 }
 
-tns_value_t *config_load_dir(int dir_id)
+tns_value_t *config_load_dir(UNUSED int dir_id)
 {
     return NULL;
 }
 
-tns_value_t *config_load_routes(int host_id, int server_id)
+tns_value_t *config_load_routes(UNUSED int host_id, UNUSED int server_id)
 {
     return NULL;
 }
 
-tns_value_t *config_load_hosts(int server_id)
+tns_value_t *config_load_hosts(UNUSED int server_id)
 {
     return NULL;
 }
 
-tns_value_t *config_load_server(const char *uuid)
+tns_value_t *config_load_server(UNUSED const char *uuid)
 {
     return NULL;
 }
@@ -95,7 +96,7 @@ tns_value_t *config_load_settings()
     return NULL;
 }
 
-tns_value_t *config_load_filters(int server_id)
+tns_value_t *config_load_filters(UNUSED int server_id)
 {
     return NULL;
 }

--- a/tools/config_modules/zmq.c
+++ b/tools/config_modules/zmq.c
@@ -36,9 +36,10 @@
 #include <dbg.h>
 #include <config/module.h>
 #include <config/db.h>
+#include <unused.h>
 
 
-int config_init(const char *path)
+int config_init(UNUSED const char *path)
 {
     return -1;
 }
@@ -47,32 +48,32 @@ void config_close()
 {
 }
 
-tns_value_t *config_load_handler(int handler_id)
+tns_value_t *config_load_handler(UNUSED int handler_id)
 {
     return NULL;
 }
 
-tns_value_t *config_load_proxy(int proxy_id)
+tns_value_t *config_load_proxy(UNUSED int proxy_id)
 {
     return NULL;
 }
 
-tns_value_t *config_load_dir(int dir_id)
+tns_value_t *config_load_dir(UNUSED int dir_id)
 {
     return NULL;
 }
 
-tns_value_t *config_load_routes(int host_id, int server_id)
+tns_value_t *config_load_routes(UNUSED int host_id, UNUSED int server_id)
 {
     return NULL;
 }
 
-tns_value_t *config_load_hosts(int server_id)
+tns_value_t *config_load_hosts(UNUSED int server_id)
 {
     return NULL;
 }
 
-tns_value_t *config_load_server(const char *uuid)
+tns_value_t *config_load_server(UNUSED const char *uuid)
 {
     return NULL;
 }

--- a/tools/filters/null.c
+++ b/tools/filters/null.c
@@ -1,8 +1,9 @@
 #include <filter.h>
 #include <dbg.h>
 #include <tnetstrings.h>
+#include <unused.h>
 
-StateEvent filter_transition(StateEvent state, Connection *conn, tns_value_t *config)
+StateEvent filter_transition(UNUSED StateEvent state, UNUSED Connection *conn, tns_value_t *config)
 {
     size_t len = 0;
     char *data = tns_render(config, &len);
@@ -17,7 +18,7 @@ StateEvent filter_transition(StateEvent state, Connection *conn, tns_value_t *co
 }
 
 
-StateEvent *filter_init(Server *srv, bstring load_path, int *out_nstates)
+StateEvent *filter_init(UNUSED Server *srv, UNUSED bstring load_path, int *out_nstates)
 {
     StateEvent states[] = {HANDLER, PROXY};
     *out_nstates = Filter_states_length(states);

--- a/tools/filters/rewrite.c
+++ b/tools/filters/rewrite.c
@@ -1,11 +1,12 @@
 #include <filter.h>
 #include <dbg.h>
 #include <tnetstrings.h>
+#include <unused.h>
 
 static struct tagbstring rewritePath=bsStatic("/proxy/");
 static struct tagbstring newPath=bsStatic("/");
 
-StateEvent filter_transition(StateEvent state, Connection *conn, tns_value_t *config)
+StateEvent filter_transition(StateEvent state, Connection *conn, UNUSED tns_value_t *config)
 {
 
     log_info("REWRITE: %s", bdata(conn->req->path));
@@ -52,7 +53,7 @@ StateEvent filter_transition(StateEvent state, Connection *conn, tns_value_t *co
 }
 
 
-StateEvent *filter_init(Server *srv, bstring load_path, int *out_nstates)
+StateEvent *filter_init(UNUSED Server *srv, UNUSED bstring load_path, int *out_nstates)
 {
     StateEvent states[] = {PROXY};
     *out_nstates = Filter_states_length(states);

--- a/tools/filters/sendfile.c
+++ b/tools/filters/sendfile.c
@@ -5,6 +5,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <connection.h>
+#include <unused.h>
 
 static int mydispatch(Connection *conn, tns_value_t *data)
 {
@@ -40,7 +41,7 @@ static int mydispatch(Connection *conn, tns_value_t *data)
 
 struct tagbstring SENDFILE = bsStatic("sendfile");
 
-deliver_function xrequest_init(Server *srv, bstring load_path, tns_value_t *config, bstring **keys, int *nkeys)
+deliver_function xrequest_init(UNUSED Server *srv, UNUSED bstring load_path, UNUSED tns_value_t *config, bstring **keys, int *nkeys)
 {
     static bstring sendfile=&SENDFILE;
     *keys=&sendfile;

--- a/tools/m2sh/Makefile
+++ b/tools/m2sh/Makefile
@@ -8,6 +8,9 @@ TEST_SRC=$(wildcard tests/*.c)
 TESTS=$(patsubst %.c,%,${TEST_SRC})
 LIB_SRC=$(filter-out src/m2sh.c,${SOURCES})
 LIB_OBJ=$(filter-out src/m2sh.o,${OBJECTS})
+RAGEL_OBJECTS=src/lexer.o src/cli.o
+
+$(RAGEL_OBJECTS): CFLAGS += -Wno-unused-const-variable -Wimplicit-fallthrough=0 -Wno-unused-parameter
 
 all: ../lemon/lemon tests build/m2sh
 
@@ -16,6 +19,8 @@ dev: all
 
 install: build/m2sh
 	install build/m2sh ${DESTDIR}${PREFIX}/bin
+
+src/parser.o: CFLAGS += -Wno-unused-const-variable -Wno-unused-parameter
 
 build/libm2sh.a: ${LIB_OBJ}
 	mkdir -p build

--- a/tools/m2sh/src/ast.c
+++ b/tools/m2sh/src/ast.c
@@ -37,6 +37,7 @@
 #include <dbg.h>
 #include <assert.h>
 #include <tnetstrings_impl.h>
+#include <unused.h>
 
 Value *Value_create(ValueType type, void *data) {
     Value *val = malloc(sizeof(Value));
@@ -249,7 +250,7 @@ static void AST_destroy_value(Value *val)
     free(val);
 }
 
-static void AST_destroy_cb(void *value, void *data)
+static void AST_destroy_cb(void *value, UNUSED void *data)
 {
     Pair *pair = (Pair *)value;
 

--- a/tools/m2sh/src/commands.c
+++ b/tools/m2sh/src/commands.c
@@ -34,6 +34,7 @@
 
 #include <stdio.h>
 #include <dbg.h>
+#include <unused.h>
 #include "cli.h"
 
 #include "commands.h"
@@ -53,7 +54,6 @@ typedef struct CommandHandler {
 } CommandHandler;
 
 #define check_no_extra(C) check(list_count((C)->extra) == 0, "Commands only take --option style arguments, you have %d extra.", (int)list_count((C)->extra))
-
 
 bstring option(Command *cmd, const char *name, const char *def)
 {
@@ -75,7 +75,7 @@ bstring option(Command *cmd, const char *name, const char *def)
     }
 }
 
-static int Command_version(Command *cmd)
+static int Command_version(UNUSED Command *cmd)
 {
 #include <version.h>
     printf("%s\n", VERSION);

--- a/tools/m2sh/src/commands/helpers.c
+++ b/tools/m2sh/src/commands/helpers.c
@@ -36,13 +36,14 @@
 #include "../commands.h"
 #include <routing.h>
 #include <dbg.h>
+#include <unused.h>
 
-int Command_uuid(Command *cmd)
+int Command_uuid(UNUSED Command *cmd)
 {
     return system("uuidgen");
 }
 
-static void null_destroy(Route *route, struct RouteMap *map)
+static void null_destroy(UNUSED Route *route, UNUSED struct RouteMap *map)
 {
 
 }

--- a/tools/m2sh/src/commands/running.c
+++ b/tools/m2sh/src/commands/running.c
@@ -48,6 +48,7 @@
 #include "../query_print.h"
 #include "logging.h"
 #include "running.h"
+#include <unused.h>
 
 struct ServerRun {
     int ran;
@@ -405,7 +406,7 @@ error:
     return NULL;
 }
 
-static void bstring_free(void *data, void *hint)
+static void bstring_free(UNUSED void *data, void *hint)
 {
     bdestroy((bstring)hint);
 }
@@ -610,7 +611,7 @@ int Command_control(Command *cmd)
     return exec_server_operations(cmd, control_server, "name, chroot");
 }
 
-static int run_command(bstring line, void *ignored)
+static int run_command(bstring line, UNUSED void *ignored)
 {
     bstring args = bformat("m2sh %s", bdata(line));
     int rc = Command_run(args);
@@ -619,7 +620,7 @@ static int run_command(bstring line, void *ignored)
     return rc;
 }
 
-int Command_shell(Command *cmd)
+int Command_shell(UNUSED Command *cmd)
 {
     return linenoise_runner("mongrel2> ", run_command, NULL);
 }

--- a/tools/m2sh/src/config_file.c
+++ b/tools/m2sh/src/config_file.c
@@ -39,6 +39,7 @@
 #include "ast.h"
 #include <dbg.h>
 #include <stdlib.h>
+#include <unused.h>
 
 
 #define CONFIRM_TYPE(N) check(Value_is(val, CLASS), "Not a class.");\
@@ -151,7 +152,7 @@ error:
     return -1;
 }
 
-int Mimetypes_load(tst_t *settings, Pair *pair)
+int Mimetypes_load(UNUSED tst_t *settings, Pair *pair)
 {
     const char *ext = bdata(Pair_key(pair));
     tns_value_t *res = NULL;
@@ -172,7 +173,7 @@ error:
     return -1;
 }
 
-int Settings_load(tst_t *settings, Pair *pair)
+int Settings_load(UNUSED tst_t *settings, Pair *pair)
 {
     const char *name = bdata(Pair_key(pair));
     tns_value_t *res = NULL;

--- a/tools/m2sh/src/lexer.c
+++ b/tools/m2sh/src/lexer.c
@@ -98,6 +98,7 @@ tst_t *Parse_config_string(bstring content)
 {
     Token *temp = NULL;
     void *parser = ParseAlloc(malloc);
+    char *ts = NULL;
     check_mem(parser);
     ParserState state = {.settings = NULL, .error = 0, .line_number = 1};
 
@@ -106,7 +107,6 @@ tst_t *Parse_config_string(bstring content)
     char *eof = pe;
     int cs = -1;
     int act = -1;
-    char *ts = NULL;
     char *te = NULL;
 
     
@@ -354,18 +354,10 @@ case 9:
     if(state.error) {
         Parse_print_error("SYNTAX ERROR", content, 
                 (int)(ts - bdata(content)), ++state.line_number);
-    } else if( cs == 
-#line 359 "src/lexer.c"
-0
-#line 141 "src/lexer.rl"
- ) {
+    } else if( cs == 0 ) {
         Parse_print_error("INVALID CHARACTER", content,
                 (int)(ts - bdata(content)), ++state.line_number);
-    } else if( cs >= 
-#line 366 "src/lexer.c"
-6
-#line 144 "src/lexer.rl"
- ) {
+    } else if( cs >= 6 ) {
         Parse(parser, TKEOF, NULL, &state);
     } else {
         log_err("INCOMPLETE CONFIG FILE. There needs to be more to this.");

--- a/tools/m2sh/src/lexer.rl
+++ b/tools/m2sh/src/lexer.rl
@@ -120,6 +120,7 @@ tst_t *Parse_config_string(bstring content)
 {
     Token *temp = NULL;
     void *parser = ParseAlloc(malloc);
+    char *ts = NULL;
     check_mem(parser);
     ParserState state = {.settings = NULL, .error = 0, .line_number = 1};
 
@@ -128,7 +129,6 @@ tst_t *Parse_config_string(bstring content)
     char *eof = pe;
     int cs = -1;
     int act = -1;
-    char *ts = NULL;
     char *te = NULL;
 
     %% write init;

--- a/tools/m2sh/tests/minunit.h
+++ b/tools/m2sh/tests/minunit.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <dbg.h>
 #include <stdlib.h>
+#include <unused.h>
 
 #define mu_suite_start() char *message = NULL
 
@@ -11,7 +12,7 @@
 #define mu_assert(test, message) if (!(test)) { log_err(message); return message; }
 #define mu_run_test(test) debug("\n-----%s", " " #test); message = test(); tests_run++; if (message) return message;
 
-#define RUN_TESTS(name) void taskmain(int argc, char *argv[]) {\
+#define RUN_TESTS(name) void taskmain(UNUSED int argc, char *argv[]) {\
      FILE *log_file = fopen("tests/tests.log", "a+");\
      if(!log_file) { printf("CAN'T OPEN TEST LOG\n"); exit(1); } \
      setbuf(log_file, NULL);\

--- a/tools/m2sh/tests/parser_tests.c
+++ b/tools/m2sh/tests/parser_tests.c
@@ -39,10 +39,11 @@
 #include <stdio.h>
 #include <bstring.h>
 #include <assert.h>
+#include <unused.h>
 
 int CB_FIRED = 0;
 
-int check_callback(tst_t *parent, Value *val)
+int check_callback(UNUSED tst_t *parent, UNUSED Value *val)
 {
     assert(parent && "Should get a parent.");
     assert(val && "Should get a val.");

--- a/tools/procer/procer.c
+++ b/tools/procer/procer.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <sys/wait.h>
 #include <sys/stat.h>
+#include <unused.h>
 
 extern char **environ;
 
@@ -217,7 +218,7 @@ void Action_dependency_assign(void *value, void *data)
     }
 }
 
-void Action_start_all(void *value, void *data)
+void Action_start_all(void *value, UNUSED void *data)
 {
     Action *action = (Action *)value;
     Action_start(action);

--- a/tools/procer/procer.c
+++ b/tools/procer/procer.c
@@ -243,7 +243,7 @@ void taskmain(int argc, char *argv[])
     dbg_set_log(stderr);
     glob_t profile_glob;
     int rc = 0;
-    int i = 0;
+    size_t i = 0;
     Action *action = NULL;
     tst_t *targets = NULL;
     bstring pid_file = NULL;


### PR DESCRIPTION
These patches fix most compiler warnings gcc-8 prints when compiling mongrel2.

Some warnings in generated code were just silenced, because fixing them would mean changes to the code generator. And they warn about mistakes often made by humans, but probably not by code generators.

I still get some deprecation warnings regarding calls to mbedtls. As mongrel2 uses the system version of mbedtls, this depends on the installed version of mbedtls. Fixing those warnings by using the recommended replacements may reduce compatibility with older versions of mbedtls, which is why I didn't fix those warnings now.