### PR TITLE
Fix crash when reading websocket packet after deliver task has stopped

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -1234,7 +1234,7 @@ void Connection_task(void *v)
     }
 
 error: // fallthrough
-    if(conn->handler) {
+    if(conn->deliverTaskStatus == DT_RUNNING) {
         Connection_handler_notify_leave(conn);
     }
 
@@ -1326,7 +1326,6 @@ void Connection_deliver_task(void *v)
         msg.data=NULL;
     }
 error:
-    conn->handler = NULL; // we're shutting down, don't notify anything else
     conn->deliverTaskStatus=DT_DYING;
     tns_value_destroy(msg.data);
     while(!list_isempty(conn->deliverQueue)) {


### PR DESCRIPTION
Previously, conn->handler was set to NULL when the deliver task stopped. This was likely intended to prevent sending messages to the backend after the backend had sent a close message. However, the websocket code relies on conn->handler remaining non-NULL, and setting it to NULL only ever prevented sending leave notifications. So, let's just not set it to NULL, and use the deliver task status to decide whether to send leave notifications.