### PR TITLE
Add missing header to m2sh

### DIFF
--- a/tools/m2sh/src/commands/running.c
+++ b/tools/m2sh/src/commands/running.c
@@ -43,6 +43,8 @@
 #include <pattern.h>
 #include <register.h>
 
+#include <sys/wait.h>
+
 #include "../linenoise.h"
 #include "../commands.h"
 #include "../query_print.h"


### PR DESCRIPTION
<sys/wait.h> is required for posix conformance (and building on freebsd)