### PR TITLE
fix multiple definition error when building with gcc10

### DIFF
--- a/src/unixy.h
+++ b/src/unixy.h
@@ -38,7 +38,7 @@
 #include <bstring.h>
 #include <unistd.h>
 
-char *m2program;
+extern char *m2program;
 
 int Unixy_chroot(bstring path);
 


### PR DESCRIPTION
Fixes #343

The original PR was against the wrong base branch