### PR TITLE
fix build with gcc 4.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ all: bin/mongrel2 tests m2sh procer
 
 ${OBJECTS_NOEXT}: CFLAGS += ${NOEXTCFLAGS}
 ${OBJECTS}: | builddirs
-$(RAGEL_OBJECTS): CFLAGS += -Wno-unused-const-variable -Wimplicit-fallthrough=0
 
 .PHONY: builddirs
 builddirs:

--- a/tools/m2sh/Makefile
+++ b/tools/m2sh/Makefile
@@ -10,7 +10,7 @@ LIB_SRC=$(filter-out src/m2sh.c,${SOURCES})
 LIB_OBJ=$(filter-out src/m2sh.o,${OBJECTS})
 RAGEL_OBJECTS=src/lexer.o src/cli.o
 
-$(RAGEL_OBJECTS): CFLAGS += -Wno-unused-const-variable -Wimplicit-fallthrough=0 -Wno-unused-parameter
+$(RAGEL_OBJECTS): CFLAGS += -Wno-unused-parameter
 
 all: ../lemon/lemon tests build/m2sh
 
@@ -20,7 +20,7 @@ dev: all
 install: build/m2sh
 	install build/m2sh ${DESTDIR}${PREFIX}/bin
 
-src/parser.o: CFLAGS += -Wno-unused-const-variable -Wno-unused-parameter
+src/parser.o: CFLAGS += -Wno-unused-parameter
 
 build/libm2sh.a: ${LIB_OBJ}
 	mkdir -p build


### PR DESCRIPTION
Drop `-Wno-unused-const-variable -Wimplicit-fallthrough=0` as `-Wno-implicit-fallthrough -Wno-unused-const-variable` is already set in `CFLAGS`. This will avoid the following build failure with gcc 4.8 raised since version 1.13.0 and https://github.com/mongrel2/mongrel2/commit/725209578599bd7784753d86aee34f6441ff78a5:
```
arm-none-linux-gnueabi-gcc: error: unrecognized command line option '-Wimplicit-fallthrough=0'
```

Fixes:
 - http://autobuild.buildroot.org/results/de324b733e09057c87352220069fe65f6e535eb8

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>