### PR TITLE
Fix check for MBEDTLS_HAVEGE_C

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -182,7 +182,7 @@ int Server_init_rng(Server *srv)
 #ifdef HAS_ARC4RANDOM
         srv->rng_func=arc4random_entropy_func;
         srv->rng_ctx = NULL;
-#elif MBEDTLS_HAVEGE_C
+#elif defined(MBEDTLS_HAVEGE_C)
         log_warn("entropy source unavailable. falling back to havege rng");
 
         ctx = calloc(sizeof(mbedtls_havege_state), 1);


### PR DESCRIPTION
Commit https://github.com/mongrel2/mongrel2/commit/8a6db3beb32da1d66757a746f440d92edff166f9 changed:
```c
#ifdef MBEDTLS_HAVEGE_C
```
to 
```c
#elif MBEDTLS_HAVEGE_C
```

However, the later is not the same and causes build error as `MBEDTLS_HAVEGE_C` is not set to any value but just `#define MBEDTLS_HAVEGE_C`
```
gcc-5 -g -O2 -Wall -Wextra -Isrc -Isrc/mbedtls/include -pthread -rdynamic -DNDEBUG   -D_FILE_OFFSET_BITS=64 -DAUTHBIND_HELPER=\"/usr/lib/authbind/helper\" -fPIC    -c -o src/server.o src/server.c
  src/server.c: In function ‘Server_init_rng’:
  src/server.c:185:23: error: #elif with no expression
  <builtin>: recipe for target 'src/server.o' failed
  make: *** [src/server.o] Error 1
```

Seen in https://github.com/Homebrew/homebrew-core/pull/96742